### PR TITLE
Conformance urls voor ogcapi procceses

### DIFF
--- a/engine/config.go
+++ b/engine/config.go
@@ -73,6 +73,7 @@ type OgcAPI struct {
 	Styles     *OgcAPIStyles       `yaml:"styles"`
 	Features   *OgcAPIFeatures     `yaml:"features"`
 	Maps       *OgcAPIMaps         `yaml:"maps"`
+	Processes  *OgcAPIProcesses    `yaml:"processes"`
 }
 
 type GeoSpatialCollections []GeoSpatialCollection
@@ -178,6 +179,12 @@ type OgcAPIFeatures struct {
 
 type OgcAPIMaps struct {
 	Collections GeoSpatialCollections `yaml:"collections"`
+}
+
+type OgcAPIProcesses struct {
+	SupportsDismiss  bool    `yaml:"supportsDismiss"`
+	SupportsCallback bool    `yaml:"supportsCallback"`
+	ProcessesServer  YAMLURL `yaml:"processesServer"`
 }
 
 type SupportedSrs struct {

--- a/examples/config_processes.yaml
+++ b/examples/config_processes.yaml
@@ -1,0 +1,12 @@
+---
+title: PDOK Updater
+# yamllint disable rule:trailing-spaces
+abstract: |
+  updater conform OGC API Processes
+baseUrl: http://localhost:8080
+# yamllint enable rule:trailing-spaces
+ogcApi:
+  processes:
+    processesServer: http://localhost:8081/ogcapi
+    supportsCallback: FALSE
+    supportsDismiss: TRUE

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/PDOK/gokoala/ogc/processes"
 	"log"
 	"net"
 	"net/http"
@@ -123,6 +124,11 @@ func newRouter(engine *gokoalaEngine.Engine, resourcesDir string) *chi.Mux {
 	// OGC Styles API
 	if engine.Config.OgcAPI.Styles != nil {
 		styles.NewStyles(engine, router)
+	}
+
+	// OGC Processe API
+	if engine.Config.OgcAPI.Processes != nil {
+		processes.NewProcesses(engine, router)
 	}
 
 	// Resources endpoint to serve static assets

--- a/ogc/common/core/templates/conformance.go.html
+++ b/ogc/common/core/templates/conformance.go.html
@@ -46,6 +46,17 @@
                     {{/* <li>http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tiff</li> */}}
                     {{/* <li>http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/netcdf</li> */}}
                 {{ end }}
+
+                {{ if .Config.OgcAPI.Processes }}
+                    <li><a href=">http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/job-list" target="_blank">http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/job-list</a></li>
+                    <li><a href="http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/ogc-process-description" target="_blank">http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/ogc-process-description</a></li>
+                    {{ if .Config.OgcAPI.Processes.SupportsDismiss }}
+                        <li><a href="http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/dismiss" target="_blank">http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/dismiss</a></li>
+                    {{end}}
+                    {{ if .Config.OgcAPI.Processes.SupportsCallback }}
+                        <li><a href="http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/callback" target="_blank">http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/callback</a></li>
+                    {{end}}
+                {{end}}
             </ul>
         </p>
     </div>

--- a/ogc/common/core/templates/conformance.go.json
+++ b/ogc/common/core/templates/conformance.go.json
@@ -55,5 +55,11 @@
       {{/* ,"http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tiff" */}}
       {{/* ,"http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/netcdf" */}}
     {{end}}
+
+    {{ if .Config.OgcAPI.Processes }}
+      "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/job-list"
+    {{end}}
+
+
   ]
 }

--- a/ogc/common/core/templates/conformance.go.json
+++ b/ogc/common/core/templates/conformance.go.json
@@ -57,7 +57,7 @@
     {{end}}
 
     {{ if .Config.OgcAPI.Processes }}
-      "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/job-list"
+      ,"http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/job-list"
     {{end}}
 
 

--- a/ogc/common/core/templates/conformance.go.json
+++ b/ogc/common/core/templates/conformance.go.json
@@ -58,6 +58,13 @@
 
     {{ if .Config.OgcAPI.Processes }}
       ,"http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/job-list"
+      ,"http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/ogc-process-description"
+      {{ if .Config.OgcAPI.Processes.SupportsDismiss }}
+        ,"http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/dismiss"
+      {{end}}
+      {{ if .Config.OgcAPI.Processes.SupportsCallback }}
+        ,"http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/callback"
+      {{end}}
     {{end}}
 
 

--- a/ogc/processes/main.go
+++ b/ogc/processes/main.go
@@ -1,0 +1,28 @@
+package processes
+
+import (
+	"github.com/PDOK/gokoala/engine"
+	"github.com/go-chi/chi/v5"
+	"net/http"
+)
+
+type Processes struct {
+	engine *engine.Engine
+}
+
+func NewProcesses(e *engine.Engine, router *chi.Mux) *Processes {
+	processes := &Processes{engine: e}
+	router.Handle("/jobs*", processes.forwarder(e.Config.OgcAPI.Processes.ProcessesServer))
+	router.Handle("/processes*", processes.forwarder(e.Config.OgcAPI.Processes.ProcessesServer))
+	router.Handle("/api*", processes.forwarder(e.Config.OgcAPI.Processes.ProcessesServer))
+	return processes
+}
+
+func (p *Processes) forwarder(processServer engine.YAMLURL) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		targetURL := *processServer.URL
+		targetURL.Path = processServer.URL.Path + r.URL.Path
+		targetURL.RawQuery = r.URL.RawQuery
+		p.engine.ReverseProxy(w, r, &targetURL, false, "")
+	}
+}


### PR DESCRIPTION
# Omschrijving

OGC API processes toegevoegd aan gokoala
icm met OGC API Processes wordt gokoala als proxy gebruikt zodat uniforme layout en styling gebruikt wordt over de verschilllende OGA API implementaties heen. Verder wordt alleen de conformiteit en landingspagina door gokoala afgehandeld 

https://dev.kadaster.nl/jira/browse/PDOK-15164

## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Nieuwe feature

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [ ] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)