### PR TITLE
swap row/col for tile server

### DIFF
--- a/engine/config.go
+++ b/engine/config.go
@@ -180,12 +180,14 @@ type OgcAPI3dGeoVolumes struct {
 }
 
 type OgcAPITiles struct {
-	Title        string                `yaml:"title" validate:"required"`
-	Abstract     string                `yaml:"abstract" validate:"required"`
-	TileServer   YAMLURL               `yaml:"tileServer" validate:"required,url"`
-	Types        []string              `yaml:"types" validate:"required"`
-	SupportedSrs []SupportedSrs        `yaml:"supportedSrs" validate:"required,dive"`
-	Collections  GeoSpatialCollections `yaml:"collections"`
+	Title      string  `yaml:"title" validate:"required"`
+	Abstract   string  `yaml:"abstract" validate:"required"`
+	TileServer YAMLURL `yaml:"tileServer" validate:"required,url"`
+	// Optional template to the vector tiles on the tileserver. Defaults to {tms}/{z}/{x}/{y}.pbf.
+	URITemplateTiles *string               `yaml:"uriTemplateTiles"`
+	Types            []string              `yaml:"types" validate:"required"`
+	SupportedSrs     []SupportedSrs        `yaml:"supportedSrs" validate:"required,dive"`
+	Collections      GeoSpatialCollections `yaml:"collections"`
 }
 
 type OgcAPIStyles struct {

--- a/ogc/tiles/main.go
+++ b/ogc/tiles/main.go
@@ -144,10 +144,10 @@ func (t *Tiles) Tile() http.HandlerFunc {
 					" Mapbox Vector Tiles (?f=mvt) tiles are supported", http.StatusBadRequest)
 				return
 			}
-			tileCol += ".pbf"
 		}
 
-		path, _ := url.JoinPath("/", tileMatrixSetID, tileMatrix, tileRow, tileCol)
+		// ogc spec is (default) z/row/col but tileserver is z/col/row (z/x/y)
+		path, _ := url.JoinPath("/", tileMatrixSetID, tileMatrix, tileCol, tileRow+".pbf")
 
 		target, err := url.Parse(t.engine.Config.OgcAPI.Tiles.TileServer.String() + path)
 		if err != nil {

--- a/ogc/tiles/main.go
+++ b/ogc/tiles/main.go
@@ -16,6 +16,7 @@ const (
 	templatesDir       = "ogc/tiles/templates/"
 	tilesPath          = "/tiles"
 	tileMatrixSetsPath = "/tileMatrixSets"
+	defaultTilesTmpl   = "{tms}/{z}/{x}/{y}.pbf"
 )
 
 type Tiles struct {
@@ -147,7 +148,12 @@ func (t *Tiles) Tile() http.HandlerFunc {
 		}
 
 		// ogc spec is (default) z/row/col but tileserver is z/col/row (z/x/y)
-		path, _ := url.JoinPath("/", tileMatrixSetID, tileMatrix, tileCol, tileRow+".pbf")
+		replacer := strings.NewReplacer("{tms}", tileMatrixSetID, "{z}", tileMatrix, "{x}", tileCol, "{y}", tileRow)
+		tilesTmpl := defaultTilesTmpl
+		if t.engine.Config.OgcAPI.Tiles.URITemplateTiles != nil {
+			tilesTmpl = *t.engine.Config.OgcAPI.Tiles.URITemplateTiles
+		}
+		path, _ := url.JoinPath("/", replacer.Replace(tilesTmpl))
 
 		target, err := url.Parse(t.engine.Config.OgcAPI.Tiles.TileServer.String() + path)
 		if err != nil {

--- a/ogc/tiles/main_test.go
+++ b/ogc/tiles/main_test.go
@@ -158,6 +158,21 @@ func TestTiles_Tile(t *testing.T) {
 				statusCode: http.StatusBadRequest,
 			},
 		},
+		{
+			name: "different uriTemplateTiles",
+			fields: fields{
+				configFile:      "ogc/tiles/testdata/config_minimal_tiles_2.yaml",
+				url:             "http://localhost:8080/tiles/:tileMatrixSetId/:tileMatrix/:tileRow/:tileCol?f=mvt",
+				tileMatrixSetID: "NetherlandsRDNewQuad",
+				tileMatrix:      "5",
+				tileRow:         "10",
+				tileCol:         "15",
+			},
+			want: want{
+				body:       "/foo/NetherlandsRDNewQuad/5/10/15",
+				statusCode: http.StatusOK,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/ogc/tiles/main_test.go
+++ b/ogc/tiles/main_test.go
@@ -139,7 +139,7 @@ func TestTiles_Tile(t *testing.T) {
 				tileCol:         "15",
 			},
 			want: want{
-				body:       "/NetherlandsRDNewQuad/5/10/15.pbf",
+				body:       "/NetherlandsRDNewQuad/5/15/10.pbf",
 				statusCode: http.StatusOK,
 			},
 		},

--- a/ogc/tiles/testdata/config_minimal_tiles_2.yaml
+++ b/ogc/tiles/testdata/config_minimal_tiles_2.yaml
@@ -15,6 +15,8 @@ ogcApi:
     # which hosts the tiles.
     tileServer:
       http://localhost:9090
+    uriTemplateTiles:
+      /foo/{tms}/{z}/{y}/{x}
     types:
       - vector
     supportedSrs:


### PR DESCRIPTION
# Omschrijving

De tileserver (t-rex) genereert x/y cq col/row, niet row/col zoals in ogc api spec. Dus swappen.

https://dev.kadaster.nl/jira/browse/PDOK-15415

## Type verandering

- Bugfix

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [x] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)