### PR TITLE
disable more xy-swap

### DIFF
--- a/ogc/tiles/templates/tiles/NetherlandsRDNewQuad.go.html
+++ b/ogc/tiles/templates/tiles/NetherlandsRDNewQuad.go.html
@@ -11,14 +11,13 @@
             tile volgens het <a href="/tileMatrixSets/NetherlandsRDNewQuad">NetherlandsRDNewQuad</a> tiling scheme.
             In sommige tools is het ook mogelijk om dit via <a href="tiles/NetherlandsRDNewQuad?f=tilejson">TileJSON</a>
             in te laden.
-            <p>
-                <code>{{ .Config.BaseURL }}/tiles/NetherlandsRDNewQuad/{tileMatrix}/{tileRow}/{tileCol}?f=mvt</code>
-            </p>
+        </p>
+        <code>{{ .Config.BaseURL }}/tiles/NetherlandsRDNewQuad/{tileMatrix}/{tileRow}/{tileCol}?f=mvt</code>
+        <p>
             <app-vectortile-view style="width: 800px; height: 600px;" 
             tile-url="{{ .Config.BaseURL }}/tiles/NetherlandsRDNewQuad" 
             zoom="12" 
-            center-x="5.3896944" center-y="52.1562499"
-            xy-swap="false">
+            center-x="5.3896944" center-y="52.1562499">
             </app-vectortile-view>   
         </p>
         <h2>Tile matrix set limits</h2>

--- a/webcomponents/vectortile-view-component/README.md
+++ b/webcomponents/vectortile-view-component/README.md
@@ -24,7 +24,7 @@ Embed the webcomponent in a third party web application
 
     <app-vectortile-view style="width: 800px; height: 600px;"
     tile-url="https://api.pdok.nl/lv/bag/ogc/v0_1/tiles/NetherlandsRDNewQuad" zoom=12 center-x=5.3896944
-    center-y=52.1562499 xy-swap="true">
+    center-y=52.1562499>
   </app-vectortile-view>
 
 see index.html for other samples.

--- a/webcomponents/vectortile-view-component/src/index.html
+++ b/webcomponents/vectortile-view-component/src/index.html
@@ -21,21 +21,20 @@
     tile-url="https://demo.ldproxy.net/daraa/tiles/WebMercatorQuad" zoom=13 center-x=36.1033 center-y=32.6264>
   </app-vectortile-view>
 
-  <H2>BAG WebMercato</H2>
+  <H2>BAG WebMercator</H2>
   <app-vectortile-view style="width: 800px; height: 600px;"
-    tile-url="https://api.pdok.nl/lv/bag/ogc/v0_1/tiles/WebMercatorQuad" zoom=17 center-x=5.3896944 center-y=52.1562499  xy-swap="true">
- 
+    tile-url="https://api.pdok.nl/lv/bag/ogc/v0_1/tiles/WebMercatorQuad" zoom=17 center-x=5.3896944 center-y=52.1562499>
   </app-vectortile-view>
 
   <H2>BAG RD</H2>
   <app-vectortile-view style="width: 800px; height: 600px;"
     tile-url="https://api.pdok.nl/lv/bag/ogc/v0_1/tiles/NetherlandsRDNewQuad" zoom=12 center-x=5.3896944
-    center-y=52.1562499 xy-swap="true">
+    center-y=52.1562499>
   </app-vectortile-view>
 
   <H2>BAG EU grid (not working Yet)</H2>
   <app-vectortile-view style="width: 800px; height: 600px;"
-    tile-url="https://api.pdok.nl/lv/bag/ogc/v0_1/tiles/EuropeanETRS89_GRS80Quad_Draft" " zoom=14 center-x=5.3896944
-    center-y=52.1562499 xy-swap="true"></app-vectortile-view>
+    tile-url="https://api.pdok.nl/lv/bag/ogc/v0_1/tiles/EuropeanETRS89_GRS80Quad_Draft" zoom=14 center-x=5.3896944
+    center-y=52.1562499></app-vectortile-view>
 </body>
 </html>


### PR DESCRIPTION
# Omschrijving

Ik had xy-swap al uitgezet. Misschien wordt de string `"false"` nog als true gezien?

https://dev.kadaster.nl/jira/browse/PDOK-15415

## Type verandering

- Minor change (typo, formatting, version bump)

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [ ] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)