### PR TITLE
Cesium seems to reason from the collection without the /3dtiles suffi…

### DIFF
--- a/ogc/geovolumes/main.go
+++ b/ogc/geovolumes/main.go
@@ -30,6 +30,10 @@ func NewThreeDimensionalGeoVolumes(e *engine.Engine, router *chi.Mux) *ThreeDime
 	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/3dtiles/{tileMatrix}/{tileRow}/{tileColAndSuffix}", geoVolumes.Tile())
 	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/3dtiles/{tilePathPrefix}/{tileMatrix}/{tileRow}/{tileColAndSuffix}", geoVolumes.Tile())
 
+	// '/3dtiles/' path is preferred but optional when requesting the actual tiles.
+	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/{tileMatrix}/{tileRow}/{tileColAndSuffix}", geoVolumes.Tile())
+	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/{tilePathPrefix}/{tileMatrix}/{tileRow}/{tileColAndSuffix}", geoVolumes.Tile())
+
 	return geoVolumes
 }
 


### PR DESCRIPTION
…x (probably because /3dtiles is a tileset.json). So keep supporting this.

# Omschrijving

Een omschrijving van wat je hebt toegevoegd/veranderd:

https://dev.kadaster.nl/jira/browse/PDOK-

## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Minor change (typo, formatting, version bump)
- Nieuwe feature
- Verbetering oude feature
- Bugfix
- Refactor
- Aanpassing van de configuratie
- Breaking change

# Checklist:

- [ ] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [ ] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)