### PR TITLE
Add support for a Quantized Mesh DTM (Digital Terrain Model)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,14 @@ jobs:
 
       - name: Test
         run: go test -v ./...
+
+      - name: Update coverage report
+        uses: ncruces/go-coverage-report@v0
+        with:
+          report: true
+          chart: false
+          amend: true
+          reuse-go: true
+        if: |
+          github.event_name == 'push'
+        continue-on-error: true

--- a/engine/config.go
+++ b/engine/config.go
@@ -203,17 +203,21 @@ type CollectionEntry3dGeoVolumes struct {
 	// Optional basepath to 3D tiles on the tileserver. Defaults to the collection ID.
 	TileServerPath *string `yaml:"tileServerPath"`
 
-	// Optional URI template for individual 3D tiles, defaults to "tiles/{level}/{x}/{y}.glb".
-	URITemplate3dTiles *string `yaml:"uriTemplate3dTiles"`
+	// URI template for individual 3D tiles.
+	URITemplate3dTiles *string `yaml:"uriTemplate3dTiles" validate:"required_without_all=URITemplateDTM"`
 
 	// Optional URI template for subtrees, only required when "implicit tiling" extension is used.
 	URITemplateImplicitTilingSubtree *string `yaml:"uriTemplateImplicitTilingSubtree"`
 
 	// URI template for digital terrain model (DTM) in Quantized Mesh format, REQUIRED when you want to serve a DTM.
-	URITemplateDTM *string `yaml:"uriTemplateDTM"`
+	URITemplateDTM *string `yaml:"uriTemplateDTM" validate:"required_without_all=URITemplate3dTiles"`
 
 	// Optional URL to 3D viewer to visualize the given collection of 3D Tiles.
 	URL3DViewer *YAMLURL `yaml:"3dViewerUrl" validate:"url"`
+}
+
+func (gv *CollectionEntry3dGeoVolumes) Has3DTiles() bool {
+	return gv.URITemplate3dTiles != nil
 }
 
 func (gv *CollectionEntry3dGeoVolumes) HasDTM() bool {

--- a/engine/config.go
+++ b/engine/config.go
@@ -49,8 +49,8 @@ func setDefaults(config *Config) {
 }
 
 func validate(config *Config) {
-	validate := validator.New()
-	err := validate.Struct(config)
+	v := validator.New()
+	err := v.Struct(config)
 	if err != nil {
 		var ive *validator.InvalidValidationError
 		if ok := errors.Is(err, ive); ok {
@@ -151,7 +151,16 @@ func (g GeoSpatialCollections) Unique() []GeoSpatialCollection {
 		flattened = append(flattened, v)
 	}
 	sort.Slice(flattened, func(i, j int) bool {
-		return flattened[i].ID < flattened[j].ID
+		icomp := flattened[i].ID
+		jcomp := flattened[j].ID
+		// prefer to sort by title when available, collection ID otherwise
+		if flattened[i].Metadata != nil && flattened[i].Metadata.Title != nil {
+			icomp = *flattened[i].Metadata.Title
+		}
+		if flattened[j].Metadata != nil && flattened[j].Metadata.Title != nil {
+			jcomp = *flattened[j].Metadata.Title
+		}
+		return icomp < jcomp
 	})
 	return flattened
 }
@@ -200,8 +209,15 @@ type CollectionEntry3dGeoVolumes struct {
 	// Optional URI template for subtrees, only required when "implicit tiling" extension is used.
 	URITemplateImplicitTilingSubtree *string `yaml:"uriTemplateImplicitTilingSubtree"`
 
+	// URI template for digital terrain model (DTM) in Quantized Mesh format, REQUIRED when you want to serve a DTM.
+	URITemplateDTM *string `yaml:"uriTemplateDTM"`
+
 	// Optional URL to 3D viewer to visualize the given collection of 3D Tiles.
 	URL3DViewer *YAMLURL `yaml:"3dViewerUrl" validate:"url"`
+}
+
+func (gv *CollectionEntry3dGeoVolumes) HasDTM() bool {
+	return gv.URITemplateDTM != nil
 }
 
 type CollectionEntryTiles struct {

--- a/engine/config_test.go
+++ b/engine/config_test.go
@@ -1,0 +1,161 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGeoSpatialCollections_Unique(t *testing.T) {
+	tests := []struct {
+		name string
+		g    GeoSpatialCollections
+		want []GeoSpatialCollection
+	}{
+		{
+			name: "empty input",
+			g:    nil,
+			want: []GeoSpatialCollection{},
+		},
+		{
+			name: "no dups, sorted by id",
+			g: []GeoSpatialCollection{
+				{
+					ID: "3",
+				},
+				{
+					ID: "1",
+				},
+				{
+					ID: "1",
+				},
+				{
+					ID: "2",
+				},
+			},
+			want: []GeoSpatialCollection{
+				{
+					ID: "1",
+				},
+				{
+					ID: "2",
+				},
+				{
+					ID: "3",
+				},
+			},
+		},
+		{
+			name: "no dups, sorted by title",
+			g: []GeoSpatialCollection{
+				{
+					ID: "3",
+					Metadata: &GeoSpatialCollectionMetadata{
+						Title:         ptrTo("a"),
+						LastUpdatedBy: "",
+					},
+				},
+				{
+					ID: "1",
+					Metadata: &GeoSpatialCollectionMetadata{
+						Title:         ptrTo("c"),
+						LastUpdatedBy: "",
+					},
+				},
+				{
+					ID: "3",
+					Metadata: &GeoSpatialCollectionMetadata{
+						Title:         ptrTo("a"),
+						LastUpdatedBy: "",
+					},
+				},
+				{
+					ID: "2",
+					Metadata: &GeoSpatialCollectionMetadata{
+						Title:         ptrTo("b"),
+						LastUpdatedBy: "",
+					},
+				},
+			},
+			want: []GeoSpatialCollection{
+				{
+					ID: "3",
+					Metadata: &GeoSpatialCollectionMetadata{
+						Title:         ptrTo("a"),
+						LastUpdatedBy: "",
+					},
+				},
+				{
+					ID: "2",
+					Metadata: &GeoSpatialCollectionMetadata{
+						Title:         ptrTo("b"),
+						LastUpdatedBy: "",
+					},
+				},
+				{
+					ID: "1",
+					Metadata: &GeoSpatialCollectionMetadata{
+						Title:         ptrTo("c"),
+						LastUpdatedBy: "",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, tt.g.Unique(), "Unique()")
+		})
+	}
+}
+
+func TestGeoSpatialCollections_ContainsID(t *testing.T) {
+	tests := []struct {
+		name string
+		g    GeoSpatialCollections
+		id   string
+		want bool
+	}{
+		{
+			name: "ID is present",
+			g: []GeoSpatialCollection{
+				{
+					ID: "3",
+				},
+				{
+					ID: "1",
+				},
+				{
+					ID: "2",
+				},
+			},
+			id:   "1",
+			want: true,
+		},
+		{
+			name: "ID is not present",
+			g: []GeoSpatialCollection{
+				{
+					ID: "3",
+				},
+				{
+					ID: "1",
+				},
+				{
+					ID: "2",
+				},
+			},
+			id:   "55",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, tt.g.ContainsID(tt.id), "ContainsID(%v)", tt.id)
+		})
+	}
+}
+
+func ptrTo[T any](val T) *T {
+	return &val
+}

--- a/engine/contentnegotiation.go
+++ b/engine/contentnegotiation.go
@@ -12,16 +12,17 @@ const (
 	formatParam   = "f"
 	languageParam = "lang"
 
-	MediaTypeJSON        = "application/json"
-	MediaTypeHTML        = "text/html"
-	MediaTypeTileJSON    = "application/vnd.mapbox.tile+json"
-	MediaTypeMVT         = "application/vnd.mapbox-vector-tile"
-	MediaTypeMapboxStyle = "application/vnd.mapbox.style+json"
-	MediaTypeCustomStyle = "application/vnd.custom.style+json"
-	MediaTypeSLD         = "application/vnd.ogc.sld+xml;version=1.0"
-	MediaTypeOpenAPI     = "application/vnd.oai.openapi+json;version=3.0"
-	MediaTypeGeoJSON     = "application/geo+json"
-	MediaTypeJSONFG      = "application/vnd.ogc.fg+json" // https://docs.ogc.org/per/21-017r1.html#toc17
+	MediaTypeJSON          = "application/json"
+	MediaTypeHTML          = "text/html"
+	MediaTypeTileJSON      = "application/vnd.mapbox.tile+json"
+	MediaTypeMVT           = "application/vnd.mapbox-vector-tile"
+	MediaTypeMapboxStyle   = "application/vnd.mapbox.style+json"
+	MediaTypeCustomStyle   = "application/vnd.custom.style+json"
+	MediaTypeSLD           = "application/vnd.ogc.sld+xml;version=1.0"
+	MediaTypeOpenAPI       = "application/vnd.oai.openapi+json;version=3.0"
+	MediaTypeGeoJSON       = "application/geo+json"
+	MediaTypeJSONFG        = "application/vnd.ogc.fg+json" // https://docs.ogc.org/per/21-017r1.html#toc17
+	MediaTypeQuantizedMesh = "application/vnd.quantized-mesh"
 
 	FormatHTML        = "html"
 	FormatJSON        = "json"

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -246,7 +246,7 @@ func (e *Engine) ReverseProxy(w http.ResponseWriter, r *http.Request, target *ur
 	modifyResponse := func(proxyRes *http.Response) error {
 		if prefer204 {
 			// OGC spec: If the tile has no content due to lack of data in the area, but is within the data
-			// resource it's tile matrix sets and tile matrix sets limits, the HTTP response will use the status
+			// resource its tile matrix sets and tile matrix sets limits, the HTTP response will use the status
 			// code either 204 (indicating an empty tile with no content) or a 200
 			if proxyRes.StatusCode == http.StatusNotFound {
 				proxyRes.StatusCode = http.StatusNoContent

--- a/engine/templates/openapi/3dgeovolumes.go.json
+++ b/engine/templates/openapi/3dgeovolumes.go.json
@@ -13,48 +13,8 @@
   "tags" : [ ],
   "paths" : {
     {{- range $index, $type := .Config.OgcAPI.GeoVolumes.Collections -}}
+    {{ if and $type.GeoVolumes $type.GeoVolumes.URITemplate3dTiles }}
     {{- if $index -}},{{- end -}}
-
-    {{- /* keep this block at the top, since it executes a 'continue' to skip further processing */ -}}
-    {{ if and $type.GeoVolumes $type.GeoVolumes.HasDTM }}
-    "/collections/{{ $type.ID }}/quantized-mesh/{{ $type.GeoVolumes.URITemplateDTM }}" : {
-      "get" : {
-        "tags" : [ "3D Tiles" ],
-        "summary" : "retrieve digital terrain model (DTM)",
-        "description" : "Access the digital terrain model (DTM) in Quantized Mesh format.",
-        "operationId" : "{{ $type.ID }}.getDTM",
-        "parameters" : [ {
-          "$ref" : "#/components/parameters/level"
-        }, {
-          "$ref" : "#/components/parameters/x"
-        }, {
-          "$ref" : "#/components/parameters/y"
-        }, {
-          "$ref" : "#/components/parameters/v"
-        }],
-        "responses" : {
-          "200" : {
-            "description" : "The operation was executed successfully.",
-            "content" : {
-              "application/vnd.quantized-mesh" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/binary"
-                }
-              }
-            }
-          },
-          "204" : {
-            "description" : "Tile Not Found"
-          },
-          "500" : {
-            "description" : "Server Error"
-          }
-        }
-      }
-    }
-    {{ continue }} {{/* skip further processing */}}
-    {{ end }}
-
     "/collections/{{ $type.ID }}/3dtiles" : {
       "get" : {
         "tags" : [ "3D Tiles" ],
@@ -82,11 +42,7 @@
         }
       }
     },
-    {{ if and $type.GeoVolumes $type.GeoVolumes.URITemplate3dTiles }}
     "/collections/{{ $type.ID }}/3dtiles/{{ $type.GeoVolumes.URITemplate3dTiles }}" : {
-    {{ else }}
-    "/collections/{{ $type.ID }}/3dtiles/tiles/{level}/{x}/{y}.glb" : {
-    {{ end }}
       "get" : {
         "tags" : [ "3D Tiles" ],
         "summary" : "retrieve a glTF tile of the feature collection '{{ $type.ID }}'",
@@ -119,6 +75,7 @@
         }
       }
     }
+    {{ end }}
     {{ if and $type.GeoVolumes $type.GeoVolumes.URITemplateImplicitTilingSubtree }}
     ,
     "/collections/{{ $type.ID }}/3dtiles/{{ $type.GeoVolumes.URITemplateImplicitTilingSubtree }}" : {
@@ -139,6 +96,44 @@
             "description" : "The operation was executed successfully.",
             "content" : {
               "application/octet-stream" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/binary"
+                }
+              }
+            }
+          },
+          "204" : {
+            "description" : "Tile Not Found"
+          },
+          "500" : {
+            "description" : "Server Error"
+          }
+        }
+      }
+    }
+    {{ end }}
+    {{ if and $type.GeoVolumes $type.GeoVolumes.HasDTM }}
+    ,
+    "/collections/{{ $type.ID }}/quantized-mesh/{{ $type.GeoVolumes.URITemplateDTM }}" : {
+      "get" : {
+        "tags" : [ "3D Tiles" ],
+        "summary" : "retrieve digital terrain model (DTM)",
+        "description" : "Access the digital terrain model (DTM) in Quantized Mesh format.",
+        "operationId" : "{{ $type.ID }}.getDTM",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/level"
+        }, {
+          "$ref" : "#/components/parameters/x"
+        }, {
+          "$ref" : "#/components/parameters/y"
+        }, {
+          "$ref" : "#/components/parameters/v"
+        }],
+        "responses" : {
+          "200" : {
+            "description" : "The operation was executed successfully.",
+            "content" : {
+              "application/vnd.quantized-mesh" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/binary"
                 }

--- a/engine/templates/openapi/3dgeovolumes.go.json
+++ b/engine/templates/openapi/3dgeovolumes.go.json
@@ -14,6 +14,47 @@
   "paths" : {
     {{- range $index, $type := .Config.OgcAPI.GeoVolumes.Collections -}}
     {{- if $index -}},{{- end -}}
+
+    {{- /* keep this block at the top, since it executes a 'continue' to skip further processing */ -}}
+    {{ if and $type.GeoVolumes $type.GeoVolumes.HasDTM }}
+    "/collections/{{ $type.ID }}/quantized-mesh/{{ $type.GeoVolumes.URITemplateDTM }}" : {
+      "get" : {
+        "tags" : [ "3D Tiles" ],
+        "summary" : "retrieve digital terrain model (DTM)",
+        "description" : "Access the digital terrain model (DTM) in Quantized Mesh format.",
+        "operationId" : "{{ $type.ID }}.getDTM",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/level"
+        }, {
+          "$ref" : "#/components/parameters/x"
+        }, {
+          "$ref" : "#/components/parameters/y"
+        }, {
+          "$ref" : "#/components/parameters/v"
+        }],
+        "responses" : {
+          "200" : {
+            "description" : "The operation was executed successfully.",
+            "content" : {
+              "application/vnd.quantized-mesh" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/binary"
+                }
+              }
+            }
+          },
+          "204" : {
+            "description" : "Tile Not Found"
+          },
+          "500" : {
+            "description" : "Server Error"
+          }
+        }
+      }
+    }
+    {{ continue }} {{/* skip further processing */}}
+    {{ end }}
+
     "/collections/{{ $type.ID }}/3dtiles" : {
       "get" : {
         "tags" : [ "3D Tiles" ],
@@ -1633,6 +1674,15 @@
           "minimum" : 0,
           "type" : "integer",
           "format" : "int32"
+        }
+      },
+      "v" : {
+        "name" : "v",
+        "in" : "query",
+        "description" : "The version of the DTM tile.",
+        "required" : false,
+        "schema" : {
+          "type" : "string"
         }
       }
     }

--- a/examples/config_3d.yaml
+++ b/examples/config_3d.yaml
@@ -28,7 +28,7 @@ ogcApi:
       - id: NewYork
         # optional basepath to 3D tiles on the tileserver. Defaults to the collection ID.
         tileServerPath: "NewYork/3DTiles"
-        # optional URI template for individual 3D tiles, defaults to "tiles/{level}/{x}/{y}.glb"
+        # URI template for individual 3D tiles
         uriTemplate3dTiles: "3DTiles/{level}/{x}/{y}.b3m"
 
         # optional URI template for subtrees, only required when "implicit tiling" extension is used

--- a/examples/config_3d.yaml
+++ b/examples/config_3d.yaml
@@ -30,5 +30,9 @@ ogcApi:
         tileServerPath: "NewYork/3DTiles"
         # optional URI template for individual 3D tiles, defaults to "tiles/{level}/{x}/{y}.glb"
         uriTemplate3dTiles: "3DTiles/{level}/{x}/{y}.b3m"
+
         # optional URI template for subtrees, only required when "implicit tiling" extension is used
         # uriTemplateImplicitTilingSubtree: ""
+
+        # URI template for digital terrain model (DTM) in Quantized Mesh format, REQUIRED when you want to serve a DTM
+        # uriTemplateDTM: ""

--- a/ogc/common/geospatial/templates/collection.go.html
+++ b/ogc/common/geospatial/templates/collection.go.html
@@ -27,7 +27,11 @@
                     <li class="list-group-item">
                         <h5 class="card-title">3D GeoVolumes</h5>
                         <ul>
-                            <li>{{ i18n "GoTo" }} <a href="{{ .Config.BaseURL }}/collections/{{ .Params.ID }}/3dtiles">3D Tiles</a></li>
+                            {{ if and .Params.GeoVolumes .Params.GeoVolumes.HasDTM }}
+                                <li>{{ i18n "GoTo" }} <a href="{{ .Config.BaseURL }}/collections/{{ .Params.ID }}/quantized-mesh">Quantized Mesh DTM</a></li>
+                            {{ else }}
+                                <li>{{ i18n "GoTo" }} <a href="{{ .Config.BaseURL }}/collections/{{ .Params.ID }}/3dtiles">3D Tiles</a></li>
+                            {{ end }}
                             {{ if and .Params.GeoVolumes .Params.GeoVolumes.URL3DViewer }}
                             <li>{{ i18n "ViewIn" }} <a href="{{ .Params.GeoVolumes.URL3DViewer }}" target="_blank">3D viewer</a></li>
                             {{ end }}

--- a/ogc/common/geospatial/templates/collection.go.html
+++ b/ogc/common/geospatial/templates/collection.go.html
@@ -27,10 +27,11 @@
                     <li class="list-group-item">
                         <h5 class="card-title">3D GeoVolumes</h5>
                         <ul>
+                            {{ if and .Params.GeoVolumes .Params.GeoVolumes.Has3DTiles }}
+                                <li>{{ i18n "GoTo" }} <a href="{{ .Config.BaseURL }}/collections/{{ .Params.ID }}/3dtiles">3D Tiles</a></li>
+                            {{ end }}
                             {{ if and .Params.GeoVolumes .Params.GeoVolumes.HasDTM }}
                                 <li>{{ i18n "GoTo" }} <a href="{{ .Config.BaseURL }}/collections/{{ .Params.ID }}/quantized-mesh">Quantized Mesh DTM</a></li>
-                            {{ else }}
-                                <li>{{ i18n "GoTo" }} <a href="{{ .Config.BaseURL }}/collections/{{ .Params.ID }}/3dtiles">3D Tiles</a></li>
                             {{ end }}
                             {{ if and .Params.GeoVolumes .Params.GeoVolumes.URL3DViewer }}
                             <li>{{ i18n "ViewIn" }} <a href="{{ .Params.GeoVolumes.URL3DViewer }}" target="_blank">3D viewer</a></li>

--- a/ogc/common/geospatial/templates/collection.go.json
+++ b/ogc/common/geospatial/templates/collection.go.json
@@ -36,13 +36,23 @@
       "href" : "{{ .Config.BaseURL }}/collections/{{ .Params.ID }}?f=html"
     }
     {{ if and .Config.OgcAPI.GeoVolumes .Config.OgcAPI.GeoVolumes.Collections }}
-    ,
-    {
-      "rel" : "items",
-      "type" : "application/json+3dtiles",
-      "title" : "Tileset definition of collection {{ .Params.ID }} according to the OGC 3D Tiles specification",
-      "href" : "{{ .Config.BaseURL }}/collections/{{ .Params.ID }}/3dtiles?f=json"
-    }
+      {{ if and .Params.GeoVolumes .Params.GeoVolumes.HasDTM }}
+      ,
+      {
+        "rel" : "items",
+        "type" : "application/json",
+        "title" : "Digital Terrain Model '{{ .Params.ID }}' in Quantized Mesh format",
+        "href" : "{{ .Config.BaseURL }}/collections/{{ .Params.ID }}/quantized-mesh?f=json"
+      }
+      {{ else }}
+      ,
+      {
+        "rel" : "items",
+        "type" : "application/json+3dtiles",
+        "title" : "Tileset definition of collection {{ .Params.ID }} according to the OGC 3D Tiles specification",
+        "href" : "{{ .Config.BaseURL }}/collections/{{ .Params.ID }}/3dtiles?f=json"
+      }
+      {{ end }}
     {{ end }}
     {{ if and .Config.OgcAPI.Tiles .Config.OgcAPI.Tiles.Collections }}
     ,

--- a/ogc/common/geospatial/templates/collection.go.json
+++ b/ogc/common/geospatial/templates/collection.go.json
@@ -36,6 +36,15 @@
       "href" : "{{ .Config.BaseURL }}/collections/{{ .Params.ID }}?f=html"
     }
     {{ if and .Config.OgcAPI.GeoVolumes .Config.OgcAPI.GeoVolumes.Collections }}
+      {{ if and .Params.GeoVolumes .Params.GeoVolumes.Has3DTiles }}
+      ,
+      {
+        "rel" : "items",
+        "type" : "application/json+3dtiles",
+        "title" : "Tileset definition of collection {{ .Params.ID }} according to the OGC 3D Tiles specification",
+        "href" : "{{ .Config.BaseURL }}/collections/{{ .Params.ID }}/3dtiles?f=json"
+      }
+      {{ end }}
       {{ if and .Params.GeoVolumes .Params.GeoVolumes.HasDTM }}
       ,
       {
@@ -43,14 +52,6 @@
         "type" : "application/json",
         "title" : "Digital Terrain Model '{{ .Params.ID }}' in Quantized Mesh format",
         "href" : "{{ .Config.BaseURL }}/collections/{{ .Params.ID }}/quantized-mesh?f=json"
-      }
-      {{ else }}
-      ,
-      {
-        "rel" : "items",
-        "type" : "application/json+3dtiles",
-        "title" : "Tileset definition of collection {{ .Params.ID }} according to the OGC 3D Tiles specification",
-        "href" : "{{ .Config.BaseURL }}/collections/{{ .Params.ID }}/3dtiles?f=json"
       }
       {{ end }}
     {{ end }}

--- a/ogc/common/geospatial/templates/collections.go.json
+++ b/ogc/common/geospatial/templates/collections.go.json
@@ -60,12 +60,21 @@
         }
         {{ if and $cfg.OgcAPI.GeoVolumes $cfg.OgcAPI.GeoVolumes.Collections }}
           {{ if $cfg.OgcAPI.GeoVolumes.Collections.ContainsID $coll.ID }}
-          ,{
-            "rel" : "items",
-            "type" : "application/json+3dtiles",
-            "title" : "Tileset definition of collection {{ $coll.ID }} according to the OGC 3D Tiles specification",
-            "href" : "{{ $baseUrl }}/collections/{{ $coll.ID }}/3dtiles?f=json"
-          }
+            {{ if and $coll.GeoVolumes $coll.GeoVolumes.HasDTM }}
+            ,{
+              "rel" : "items",
+              "type" : "application/json",
+              "title" : "Digital Terrain Model '{{ $coll.ID }}' in Quantized Mesh format",
+              "href" : "{{ $baseUrl }}/collections/{{ $coll.ID }}/quantized-mesh?f=json"
+            }
+            {{ else }}
+            ,{
+              "rel" : "items",
+              "type" : "application/json+3dtiles",
+              "title" : "Tileset definition of collection {{ $coll.ID }} according to the OGC 3D Tiles specification",
+              "href" : "{{ $baseUrl }}/collections/{{ $coll.ID }}/3dtiles?f=json"
+            }
+            {{end}}
           {{end}}
         {{end}}
         {{ if and $cfg.OgcAPI.Tiles $cfg.OgcAPI.Tiles.Collections }}
@@ -116,6 +125,15 @@
       "content" : [
         {{ if and $cfg.OgcAPI.GeoVolumes $cfg.OgcAPI.GeoVolumes.Collections }}
           {{ if $cfg.OgcAPI.GeoVolumes.Collections.ContainsID $coll.ID }}
+            {{ if and $coll.GeoVolumes $coll.GeoVolumes.HasDTM }}
+            {
+              "rel" : "original",
+              "type" : "application/json",
+              "title" : "Digital Terrain Model '{{ $coll.ID }}' in Quantized Mesh format",
+              "href" : "{{ $baseUrl }}/collections/{{ $coll.ID }}?f=json",
+              "collectionType": "3d-container"
+            }
+            {{else}}
             {
               "rel" : "original",
               "type" : "application/json+3dtiles",
@@ -123,6 +141,7 @@
               "href" : "{{ $baseUrl }}/collections/{{ $coll.ID }}/3dtiles?f=json",
               "collectionType": "3d-container"
             }
+            {{end}}
           {{end}}
         {{end}}
       ]

--- a/ogc/common/geospatial/templates/collections.go.json
+++ b/ogc/common/geospatial/templates/collections.go.json
@@ -60,14 +60,7 @@
         }
         {{ if and $cfg.OgcAPI.GeoVolumes $cfg.OgcAPI.GeoVolumes.Collections }}
           {{ if $cfg.OgcAPI.GeoVolumes.Collections.ContainsID $coll.ID }}
-            {{ if and $coll.GeoVolumes $coll.GeoVolumes.HasDTM }}
-            ,{
-              "rel" : "items",
-              "type" : "application/json",
-              "title" : "Digital Terrain Model '{{ $coll.ID }}' in Quantized Mesh format",
-              "href" : "{{ $baseUrl }}/collections/{{ $coll.ID }}/quantized-mesh?f=json"
-            }
-            {{ else }}
+            {{ if and $coll.GeoVolumes $coll.GeoVolumes.Has3DTiles }}
             ,{
               "rel" : "items",
               "type" : "application/json+3dtiles",
@@ -75,6 +68,14 @@
               "href" : "{{ $baseUrl }}/collections/{{ $coll.ID }}/3dtiles?f=json"
             }
             {{end}}
+            {{ if and $coll.GeoVolumes $coll.GeoVolumes.HasDTM }}
+            ,{
+              "rel" : "items",
+              "type" : "application/json",
+              "title" : "Digital Terrain Model '{{ $coll.ID }}' in Quantized Mesh format",
+              "href" : "{{ $baseUrl }}/collections/{{ $coll.ID }}/quantized-mesh?f=json"
+            }
+            {{ end }}
           {{end}}
         {{end}}
         {{ if and $cfg.OgcAPI.Tiles $cfg.OgcAPI.Tiles.Collections }}

--- a/ogc/features/datasources/geopackage/backend_cloud.go
+++ b/ogc/features/datasources/geopackage/backend_cloud.go
@@ -24,7 +24,7 @@ type cloudGeoPackage struct {
 }
 
 func newCloudBackedGeoPackage(gpkg *engine.GeoPackageCloud) geoPackageBackend {
-	log.Printf("connecting to Cloud-Backed GeoPackage: %s\n", gpkg.Connection)
+	log.Printf("connecting to Cloud-Backed GeoPackage on '%s' in container '%s'\n", gpkg.Connection, gpkg.Container)
 	vfs, err := cloudsqlitevfs.NewVFS(vfsName, gpkg.Connection, gpkg.User, gpkg.Auth, gpkg.Container, getCacheDir(gpkg))
 	if err != nil {
 		log.Fatalf("failed to connect with Cloud-Backed GeoPackage: %v", err)

--- a/ogc/geovolumes/main.go
+++ b/ogc/geovolumes/main.go
@@ -38,7 +38,7 @@ func NewThreeDimensionalGeoVolumes(e *engine.Engine, router *chi.Mux) *ThreeDime
 	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/quantized-mesh/{tileMatrix}/{tileRow}/{tileColAndSuffix}", geoVolumes.Tile())
 	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/quantized-mesh/{tilePathPrefix}/{tileMatrix}/{tileRow}/{tileColAndSuffix}", geoVolumes.Tile())
 
-	// path '/3dtiles/' or '/quantized-mesh' is preferred but optional when requesting the actual tiles/tileset.
+	// path '/3dtiles' or '/quantized-mesh' is preferred but optional when requesting the actual tiles/tileset.
 	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/{explicitTileSet}.json", geoVolumes.ExplicitTileset())
 	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/{tileMatrix}/{tileRow}/{tileColAndSuffix}", geoVolumes.Tile())
 	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/{tilePathPrefix}/{tileMatrix}/{tileRow}/{tileColAndSuffix}", geoVolumes.Tile())
@@ -91,8 +91,8 @@ func (t *ThreeDimensionalGeoVolumes) Tile() http.HandlerFunc {
 		tileColAndSuffix := chi.URLParam(r, "tileColAndSuffix")
 
 		contentType := ""
-		if collection.GeoVolumes != nil && collection.GeoVolumes.URITemplateDTM != nil {
-			// DTM has a specialized mediatype, although application/octet-stream will also work
+		if collection.GeoVolumes != nil && collection.GeoVolumes.HasDTM() {
+			// DTM has a specialized mediatype, although application/octet-stream will also work with Cesium
 			contentType = engine.MediaTypeQuantizedMesh
 		}
 

--- a/ogc/geovolumes/main.go
+++ b/ogc/geovolumes/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/PDOK/gokoala/engine"
 	"github.com/PDOK/gokoala/ogc/common/geospatial"
@@ -26,12 +27,18 @@ func NewThreeDimensionalGeoVolumes(e *engine.Engine, router *chi.Mux) *ThreeDime
 		engine: e,
 	}
 
-	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/3dtiles", geoVolumes.CollectionContent())
+	// 3D Tiles
+	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/3dtiles", geoVolumes.CollectionContent("tileset.json"))
 	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/3dtiles/{explicitTileSet}.json", geoVolumes.ExplicitTileset())
 	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/3dtiles/{tileMatrix}/{tileRow}/{tileColAndSuffix}", geoVolumes.Tile())
 	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/3dtiles/{tilePathPrefix}/{tileMatrix}/{tileRow}/{tileColAndSuffix}", geoVolumes.Tile())
 
-	// '/3dtiles/' path is preferred but optional when requesting the actual tiles/tileset.
+	// DTM/Quantized Mesh
+	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/quantized-mesh", geoVolumes.CollectionContent("layer.json"))
+	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/quantized-mesh/{tileMatrix}/{tileRow}/{tileColAndSuffix}", geoVolumes.Tile())
+	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/quantized-mesh/{tilePathPrefix}/{tileMatrix}/{tileRow}/{tileColAndSuffix}", geoVolumes.Tile())
+
+	// path '/3dtiles/' or '/quantized-mesh' is preferred but optional when requesting the actual tiles/tileset.
 	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/{explicitTileSet}.json", geoVolumes.ExplicitTileset())
 	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/{tileMatrix}/{tileRow}/{tileColAndSuffix}", geoVolumes.Tile())
 	router.Get(geospatial.CollectionsPath+"/{3dContainerId}/{tilePathPrefix}/{tileMatrix}/{tileRow}/{tileColAndSuffix}", geoVolumes.Tile())
@@ -39,11 +46,14 @@ func NewThreeDimensionalGeoVolumes(e *engine.Engine, router *chi.Mux) *ThreeDime
 	return geoVolumes
 }
 
-// CollectionContent reverse proxy to tileserver for tileset.json (the latter contains
-// data from OGC 3D Tiles, separate spec from OGC 3D GeoVolumes)
-func (t *ThreeDimensionalGeoVolumes) CollectionContent() http.HandlerFunc {
+// CollectionContent reverse proxy to tileserver for tileset.json  OGC 3D Tiles manifest, separate
+// spec from OGC 3D GeoVolumes) or the equivalent manifest (layer.json) for a quantized mesh
+func (t *ThreeDimensionalGeoVolumes) CollectionContent(fileName string) http.HandlerFunc {
+	if !strings.HasSuffix(fileName, ".json") {
+		log.Fatalf("manifest should be a JSON file")
+	}
 	return func(w http.ResponseWriter, r *http.Request) {
-		t.tileSet(w, r, "tileset.json")
+		t.tileSet(w, r, fileName)
 	}
 }
 
@@ -60,53 +70,71 @@ func (t *ThreeDimensionalGeoVolumes) ExplicitTileset() http.HandlerFunc {
 	}
 }
 
-// Tile reverse proxy to tileserver for actual 3D tiles (from OGC 3D Tiles, separate spec from OGC 3D GeoVolumes)
+// Tile reverse proxy to tileserver for actual 3D tiles (from OGC 3D Tiles, separate spec
+// from OGC 3D GeoVolumes) or DTM Quantized Mesh tiles
 func (t *ThreeDimensionalGeoVolumes) Tile() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		containerID, err := t.containerIDToPathPrefix(chi.URLParam(r, "3dContainerId"))
+		collectionID := chi.URLParam(r, "3dContainerId")
+		collection, err := t.idToCollection(collectionID)
 		if err != nil {
 			http.NotFound(w, r)
 			return
+		}
+
+		tileServerPath := collectionID
+		if collection.GeoVolumes != nil && collection.GeoVolumes.TileServerPath != nil {
+			tileServerPath = *collection.GeoVolumes.TileServerPath
 		}
 		tilePathPrefix := chi.URLParam(r, "tilePathPrefix") // optional
 		tileMatrix := chi.URLParam(r, "tileMatrix")
 		tileRow := chi.URLParam(r, "tileRow")
 		tileColAndSuffix := chi.URLParam(r, "tileColAndSuffix")
 
-		path, _ := url.JoinPath("/", containerID, tilePathPrefix, tileMatrix, tileRow, tileColAndSuffix)
+		contentType := ""
+		if collection.GeoVolumes != nil && collection.GeoVolumes.URITemplateDTM != nil {
+			// DTM has a specialized mediatype, although application/octet-stream will also work
+			contentType = engine.MediaTypeQuantizedMesh
+		}
 
-		t.reverseProxy(w, r, path, true)
+		path, _ := url.JoinPath("/", tileServerPath, tilePathPrefix, tileMatrix, tileRow, tileColAndSuffix)
+		t.reverseProxy(w, r, path, true, contentType)
 	}
 }
 
 func (t *ThreeDimensionalGeoVolumes) tileSet(w http.ResponseWriter, r *http.Request, tileSet string) {
-	containerID, err := t.containerIDToPathPrefix(chi.URLParam(r, "3dContainerId"))
+	collectionID := chi.URLParam(r, "3dContainerId")
+	collection, err := t.idToCollection(collectionID)
 	if err != nil {
 		http.NotFound(w, r)
 		return
 	}
-	path, _ := url.JoinPath("/", containerID, tileSet)
-	t.reverseProxy(w, r, path, false)
+
+	tileServerPath := collectionID
+	if collection.GeoVolumes != nil && collection.GeoVolumes.TileServerPath != nil {
+		tileServerPath = *collection.GeoVolumes.TileServerPath
+	}
+
+	path, _ := url.JoinPath("/", tileServerPath, tileSet)
+	t.reverseProxy(w, r, path, false, "")
 }
 
-func (t *ThreeDimensionalGeoVolumes) reverseProxy(w http.ResponseWriter, r *http.Request, path string, prefer204 bool) {
+func (t *ThreeDimensionalGeoVolumes) reverseProxy(w http.ResponseWriter, r *http.Request, path string,
+	prefer204 bool, contentTypeOverwrite string) {
+
 	target, err := url.Parse(t.engine.Config.OgcAPI.GeoVolumes.TileServer.String() + path)
 	if err != nil {
 		log.Printf("invalid target url, can't proxy tiles: %v", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
-	t.engine.ReverseProxy(w, r, target, prefer204, "")
+	t.engine.ReverseProxy(w, r, target, prefer204, contentTypeOverwrite)
 }
 
-func (t *ThreeDimensionalGeoVolumes) containerIDToPathPrefix(cid string) (string, error) {
+func (t *ThreeDimensionalGeoVolumes) idToCollection(cid string) (*engine.GeoSpatialCollection, error) {
 	for _, collection := range t.engine.Config.OgcAPI.GeoVolumes.Collections {
 		if collection.ID == cid {
-			if collection.GeoVolumes != nil && collection.GeoVolumes.TileServerPath != nil {
-				return *collection.GeoVolumes.TileServerPath, nil
-			}
-			return cid, nil
+			return &collection, nil
 		}
 	}
-	return "", errors.New("no matching collection found")
+	return nil, errors.New("no matching collection found")
 }

--- a/ogc/geovolumes/main_test.go
+++ b/ogc/geovolumes/main_test.go
@@ -63,6 +63,22 @@ func TestThreeDimensionalGeoVolume_Tile(t *testing.T) {
 			},
 		},
 		{
+			name: "container_1/0/0/0/0 - DTM",
+			fields: fields{
+				configFile:       "ogc/geovolumes/testdata/config_dtm.yaml",
+				url:              "http://localhost:8080/collections/:3dContainerId/:tileMatrixSetId/:tileMatrix/:tileRow/:tileCol",
+				containerID:      "container_1",
+				tilePathPrefix:   "0",
+				tileMatrix:       "0",
+				tileRow:          "0",
+				tileColAndSuffix: "0",
+			},
+			want: want{
+				body:       "/container_1/0/0/0/0",
+				statusCode: http.StatusOK,
+			},
+		},
+		{
 			name: "container_2/1/2/3/4",
 			fields: fields{
 				configFile:       "ogc/geovolumes/testdata/config_minimal_3d.yaml",
@@ -189,6 +205,18 @@ func TestThreeDimensionalGeoVolume_ExplicitTileSet(t *testing.T) {
 			want: want{
 				body:       "/container_2/tileset-5-768-896.json",
 				statusCode: http.StatusOK,
+			},
+		},
+		{
+			name: "404",
+			fields: fields{
+				configFile:  "ogc/geovolumes/testdata/config_minimal_3d.yaml",
+				url:         "http://localhost:8080/collections/:3dContainerId/:explicitTileSet.json",
+				containerID: "container_2",
+			},
+			want: want{
+				body:       "404 page not found\n",
+				statusCode: http.StatusNotFound,
 			},
 		},
 	}

--- a/ogc/geovolumes/main_test.go
+++ b/ogc/geovolumes/main_test.go
@@ -153,7 +153,7 @@ func TestThreeDimensionalGeoVolume_CollectionContent(t *testing.T) {
 
 			newEngine := engine.NewEngine(tt.fields.configFile, "")
 			threeDimensionalGeoVolume := NewThreeDimensionalGeoVolumes(newEngine, chi.NewRouter())
-			handler := threeDimensionalGeoVolume.CollectionContent()
+			handler := threeDimensionalGeoVolume.CollectionContent("tileset.json")
 			handler.ServeHTTP(rr, req)
 
 			assert.Equal(t, tt.want.statusCode, rr.Code)
@@ -221,7 +221,7 @@ func createMockServer() (*httptest.ResponseRecorder, *httptest.Server) {
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		engine.SafeWrite(w.Write, []byte(r.URL.String()))
 	}))
-	ts.Listener.Close()
+	defer ts.Listener.Close()
 	ts.Listener = l
 	ts.Start()
 	return rr, ts

--- a/ogc/geovolumes/testdata/config_dtm.yaml
+++ b/ogc/geovolumes/testdata/config_dtm.yaml
@@ -1,9 +1,9 @@
 ---
 version: 1.0.2
-title: Minimal OGC API
-abstract: This is a minimal OGC API, offering only OGC API 3DGeoVolumes
+title: With DTM
+abstract: This is a minimal OGC API, with botch 3d Tiles and a Quantized Mesh DTM
 baseUrl: http://localhost:8080
-serviceIdentifier: Min
+serviceIdentifier: dtm
 license:
   name: MIT
   url: https://www.tldrlegal.com/license/mit-license
@@ -11,7 +11,10 @@ ogcApi:
   3dgeovolumes:
     tileServer: http://localhost:9090
     collections:
-      - id: container_1
+      - id: container_1  # DTM and 3D tiles in same collection
         uriTemplate3dTiles: "tiles/{level}/{x}/{y}.glb"
+        uriTemplateDTM: "dtm/tiles/{level}/{x}/{y}.terrain"
       - id: container_2
         uriTemplate3dTiles: "tiles2/{level}/{x}/{y}.i3d"
+      - id: container_3
+        uriTemplateDTM: "dtm/tiles/{level}/{x}/{y}.terrain"


### PR DESCRIPTION
# Omschrijving

Add support for a Quantized Mesh DTM (Digital Terrain Model) collection to OGC API 3D GeoVolumes

https://dev.kadaster.nl/jira/browse/PDOK-15712

## Type verandering

- Verbetering oude feature
- 
# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [x] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)