### PR TITLE
Fix content section of 3d GeoVolumes collection: should also include DTM

### DIFF
--- a/ogc/common/geospatial/templates/collection.go.json
+++ b/ogc/common/geospatial/templates/collection.go.json
@@ -98,13 +98,23 @@
   {{ if and .Config.OgcAPI.GeoVolumes .Config.OgcAPI.GeoVolumes.Collections }}
   ,
   "content" : [
-    {
-      "rel" : "original",
-      "type" : "application/json+3dtiles",
-      "title" : "Tileset definition of collection {{ .Params.ID }} according to the OGC 3D Tiles specification",
-      "href" : "{{ .Config.BaseURL }}/collections/{{ .Params.ID }}/3dtiles?f=json",
-      "collectionType": "3d-container"
-    }
+      {{ if and .Params.GeoVolumes .Params.GeoVolumes.Has3DTiles }}
+      {
+        "rel" : "original",
+        "type" : "application/json+3dtiles",
+        "title" : "Tileset definition of collection {{ .Params.ID }} according to the OGC 3D Tiles specification",
+        "href" : "{{ .Config.BaseURL }}/collections/{{ .Params.ID }}/3dtiles?f=json",
+        "collectionType": "3d-container"
+      }
+      {{ else if and .Params.GeoVolumes .Params.GeoVolumes.HasDTM }}
+      {
+        "rel" : "original",
+        "type" : "application/json",
+        "title" : "Digital Terrain Model '{{ .Params.ID }}' in Quantized Mesh format",
+        "href" : "{{ .Config.BaseURL }}/collections/{{ .Params.ID }}/quantized-mesh?f=json",
+        "collectionType": "3d-container"
+      }
+      {{ end }}
   ]
   {{ end }}
 }

--- a/ogc/common/geospatial/templates/collections.go.json
+++ b/ogc/common/geospatial/templates/collections.go.json
@@ -75,7 +75,7 @@
               "title" : "Digital Terrain Model '{{ $coll.ID }}' in Quantized Mesh format",
               "href" : "{{ $baseUrl }}/collections/{{ $coll.ID }}/quantized-mesh?f=json"
             }
-            {{ end }}
+            {{end}}
           {{end}}
         {{end}}
         {{ if and $cfg.OgcAPI.Tiles $cfg.OgcAPI.Tiles.Collections }}
@@ -126,20 +126,20 @@
       "content" : [
         {{ if and $cfg.OgcAPI.GeoVolumes $cfg.OgcAPI.GeoVolumes.Collections }}
           {{ if $cfg.OgcAPI.GeoVolumes.Collections.ContainsID $coll.ID }}
-            {{ if and $coll.GeoVolumes $coll.GeoVolumes.HasDTM }}
-            {
-              "rel" : "original",
-              "type" : "application/json",
-              "title" : "Digital Terrain Model '{{ $coll.ID }}' in Quantized Mesh format",
-              "href" : "{{ $baseUrl }}/collections/{{ $coll.ID }}?f=json",
-              "collectionType": "3d-container"
-            }
-            {{else}}
+            {{ if and $coll.GeoVolumes $coll.GeoVolumes.Has3DTiles }}
             {
               "rel" : "original",
               "type" : "application/json+3dtiles",
               "title" : "Tileset definition of collection {{ $coll.ID }} according to the OGC 3D Tiles specification",
               "href" : "{{ $baseUrl }}/collections/{{ $coll.ID }}/3dtiles?f=json",
+              "collectionType": "3d-container"
+            }
+            {{ else if and $coll.GeoVolumes $coll.GeoVolumes.HasDTM }}
+            {
+              "rel" : "original",
+              "type" : "application/json",
+              "title" : "Digital Terrain Model '{{ $coll.ID }}' in Quantized Mesh format",
+              "href" : "{{ $baseUrl }}/collections/{{ $coll.ID }}?f=json",
               "collectionType": "3d-container"
             }
             {{end}}


### PR DESCRIPTION
# Omschrijving

https://api.pdok.nl/kadaster/3d-basisvoorziening/ogc/v1_0-preprod/collections/digitaalterreinmodel?f=json contained 3dtiles instead of DTM reference.

## Type verandering

- Bugfix

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)