### PR TITLE
no bounding box button on map in single item in feature html

### DIFF
--- a/ogc/features/templates/feature.go.html
+++ b/ogc/features/templates/feature.go.html
@@ -59,7 +59,7 @@
         <script type="text/javascript" src="view-component/polyfills.js"></script>
         <script type="text/javascript" src="view-component/runtime.js"></script>
 
-        <app-feature-view id="viewer" background-map="{{ $cfg.OgcAPI.Features.Basemap }}"></app-feature-view>
+        <app-feature-view id="viewer" background-map="{{ $cfg.OgcAPI.Features.Basemap }}" show-bounding-box-button="false"></app-feature-view>
         <script type="module">
             const url = new URL(window.location.href)
             url.searchParams.set('f', 'json');

--- a/viewer/src/app/feature-view/feature-view.component.ts
+++ b/viewer/src/app/feature-view/feature-view.component.ts
@@ -1,4 +1,5 @@
 import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, OnChanges, Output } from '@angular/core'
+import { coerceBooleanProperty } from '@angular/cdk/coercion'
 import { Feature, MapBrowserEvent, Map as OLMap, Overlay, View } from 'ol'
 import { FeatureLike } from 'ol/Feature'
 import { PanIntoViewOptions } from 'ol/Overlay'
@@ -39,6 +40,13 @@ export class FeatureViewComponent implements OnChanges, AfterViewInit {
   @Input() backgroundMap: BackgroundMap = 'OSM'
   @Input() set projection(value: ProjectionLike) {
     this._projection = this.featureService.getProjectionMapping(value)
+  }
+  private _showBoundingBoxButton: boolean = true
+  @Input() set showBoundingBoxButton(showBox) {
+    this._showBoundingBoxButton = coerceBooleanProperty(showBox)
+  }
+  get showBoundingBoxButton() {
+    return this._showBoundingBoxButton
   }
   @Output() box = new EventEmitter<string>()
   @Output() activeFeature = new EventEmitter<FeatureLike>()
@@ -81,7 +89,9 @@ export class FeatureViewComponent implements OnChanges, AfterViewInit {
   }
 
   ngAfterViewInit() {
-    this.map.addControl(new boxControl(this.box, {}))
+    if (this._showBoundingBoxButton) {
+      this.map.addControl(new boxControl(this.box, {}))
+    }
     this.addFeatureEmit()
   }
 

--- a/viewer/src/index.html
+++ b/viewer/src/index.html
@@ -48,7 +48,8 @@
       id="wegdelensample"
       items-url="https://api.pdok.nl/lv/bgt/ogc/v1_0-preprod/collections/wegdelen/items?f=json&limit=500&crs=http://www.opengis.net/def/crs/EPSG/0/28992"
       projection="http://www.opengis.net/def/crs/EPSG/0/28992"
-      background-map="BRT">
+      background-map="BRT"
+      show-bounding-box-button="false">
     </app-feature-view>
   </body>
   <script>


### PR DESCRIPTION
Do not show bounding box select button on the single feature (item) html page 

extra option  show-bounding-box-button added with default value true 

 <app-feature-view   show-bounding-box-button="false">

removed this bottom from view 
