### PR TITLE
Perf: add option to warm up cache by traversing spatial indexes on ea…

### DIFF
--- a/engine/config.go
+++ b/engine/config.go
@@ -435,6 +435,9 @@ type GeoPackageCloudCache struct {
 
 	// max size of the local cache. Accepts human-readable size such as 100Mb, 4Gb, 1Tb, etc. When omitted 1Gb is used.
 	MaxSize string `yaml:"maxSize" default:"1Gb"`
+
+	// When true a warm-up query is executed on startup which aims to fill the local cache. Does increase startup time.
+	WarmUp bool `yaml:"warmUp" default:"false"`
 }
 
 func (cache *GeoPackageCloudCache) MaxSizeAsBytes() (int64, error) {

--- a/examples/config_features_azure.yaml
+++ b/examples/config_features_azure.yaml
@@ -49,6 +49,8 @@ ogcApi:
             container: example
             file: addresses.gpkg
             fid: fid
+            cache:
+              warmUp: true
     collections:
       - id: dutch-addresses
         tableName: addresses  # name of the feature table (optional), when omitted collection ID is used.

--- a/ogc/features/datasources/geopackage/asserts.go
+++ b/ogc/features/datasources/geopackage/asserts.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// assert required indexes in the GeoPackage exists
+// assertIndexesExist asserts required indexes in the GeoPackage exists
 func assertIndexesExist(
 	configuredCollections engine.GeoSpatialCollections,
 	featureTableByCollectionID map[string]*featureTable,

--- a/ogc/features/datasources/geopackage/asserts.go
+++ b/ogc/features/datasources/geopackage/asserts.go
@@ -60,7 +60,7 @@ group by list.name`, tableName)
 			exists = true
 		}
 	}
-	rows.Close() //nolint:sqlclosecheck // don't defer in loop
+	defer rows.Close()
 	if !exists {
 		return fmt.Errorf("missing required index: no index exists on column(s) '%s' in table '%s'",
 			columns, tableName)

--- a/ogc/features/datasources/geopackage/warmup.go
+++ b/ogc/features/datasources/geopackage/warmup.go
@@ -43,7 +43,7 @@ select minx,maxx,miny,maxy from rtree_%[1]s_%[2]s where minx <= 0 and maxx >= 0 
 	if err != nil {
 		return fmt.Errorf("failed to warm-up feature table '%s'", tableName)
 	}
-	rows.Close() //nolint:sqlclosecheck // don't defer in loop
+	defer rows.Close()
 	log.Printf("end warm-up of feature table '%s'", tableName)
 	return nil
 }

--- a/ogc/features/datasources/geopackage/warmup.go
+++ b/ogc/features/datasources/geopackage/warmup.go
@@ -1,0 +1,49 @@
+package geopackage
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/PDOK/gokoala/engine"
+	"github.com/jmoiron/sqlx"
+)
+
+// warmUpFeatureTables executes a warmup query to speedup subsequent queries.
+// This encompasses traversing index(es) to fill the local cache.
+func warmUpFeatureTables(
+	configuredCollections engine.GeoSpatialCollections,
+	featureTableByCollectionID map[string]*featureTable,
+	db *sqlx.DB) error {
+
+	for collID, table := range featureTableByCollectionID {
+		if table == nil {
+			return fmt.Errorf("given table can't be nil")
+		}
+		for _, coll := range configuredCollections {
+			if coll.ID == collID && coll.Features != nil {
+				if err := warmUpFeatureTable(table.TableName, table.GeometryColumnName, db); err != nil {
+					return err
+				}
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func warmUpFeatureTable(tableName string, geomColumnName string, db *sqlx.DB) error {
+	query := fmt.Sprintf(`
+select minx,maxx,miny,maxy from %[1]s where minx <= 0 and maxx >= 0 and miny <= 0 and maxy >= 0
+union all
+select minx,maxx,miny,maxy from rtree_%[1]s_%[2]s where minx <= 0 and maxx >= 0 and miny <= 0 and maxy >= 0;
+`, tableName, geomColumnName)
+
+	log.Printf("start warm-up of feature table '%s'", tableName)
+	rows, err := db.Queryx(query)
+	if err != nil {
+		return fmt.Errorf("failed to warm-up feature table '%s'", tableName)
+	}
+	rows.Close() //nolint:sqlclosecheck // don't defer in loop
+	log.Printf("end warm-up of feature table '%s'", tableName)
+	return nil
+}

--- a/ogc/features/json.go
+++ b/ogc/features/json.go
@@ -271,7 +271,7 @@ func getEncoder(w io.Writer) jsonEncoder {
 		encoder.SetEscapeHTML(false)
 		return encoder
 	}
-	// use ~7% faster 3rd party JSON encoder (in case of issues switch based to stdlib using env variable)
+	// use ~7% overall faster 3rd party JSON encoder (in case of issues switch back to stdlib using env variable)
 	encoder := perfjson.NewEncoder(w)
 	encoder.SetEscapeHTML(false)
 	return encoder


### PR DESCRIPTION
Add option to warm up cache by traversing spatial indexes on each feature table. Disabled by default.