### PR TITLE
Different strategy: don't init datasources in parallel, only perform …

### DIFF
--- a/ogc/features/datasources/geopackage/geopackage.go
+++ b/ogc/features/datasources/geopackage/geopackage.go
@@ -117,9 +117,12 @@ func NewGeoPackage(collections engine.GeoSpatialCollections, gpkgConfig engine.G
 		log.Fatal(err)
 	}
 	if warmUp {
-		if err = warmUpFeatureTables(collections, g.featureTableByCollectionID, g.backend.getDB()); err != nil {
-			log.Fatal(err)
-		}
+		// perform warmup async since it can take a long time
+		go func() {
+			if err = warmUpFeatureTables(collections, g.featureTableByCollectionID, g.backend.getDB()); err != nil {
+				log.Fatal(err)
+			}
+		}()
 	}
 	return g
 }


### PR DESCRIPTION
…warmUp async. Parallel init causes too many issues (also in sqlite itself)
