### PR TITLE
move Config to its own package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-package engine
+package config
 
 import (
 	"errors"
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	cookieMaxAge = 60 * 60 * 24
+	CookieMaxAge = 60 * 60 * 24
 )
 
 func NewConfig(configFile string) (*Config, error) {
@@ -60,7 +60,7 @@ func setDefaults(config *Config) error {
 		return fmt.Errorf("failed to set default configuration: %w", err)
 	}
 
-	config.CookieMaxAge = cookieMaxAge
+	config.CookieMaxAge = CookieMaxAge
 
 	if len(config.AvailableLanguages) == 0 {
 		config.AvailableLanguages = append(config.AvailableLanguages, language.Dutch) // default to Dutch only

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,4 +1,4 @@
-package engine
+package config
 
 import (
 	"os"

--- a/engine/contentnegotiation.go
+++ b/engine/contentnegotiation.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/PDOK/gokoala/config"
 	"github.com/PDOK/gokoala/engine/util"
 	"github.com/elnormous/contenttype"
 	"golang.org/x/text/language"
@@ -200,7 +201,7 @@ func setLanguageCookie(w http.ResponseWriter, lang string) {
 		Name:     languageParam,
 		Value:    lang,
 		Path:     "/",
-		MaxAge:   cookieMaxAge,
+		MaxAge:   config.CookieMaxAge,
 		SameSite: http.SameSiteStrictMode,
 		Secure:   true,
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -17,6 +17,8 @@ import (
 	texttemplate "text/template"
 	"time"
 
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 )
@@ -38,7 +40,7 @@ const (
 
 // Engine encapsulates shared non-OGC API specific logic
 type Engine struct {
-	Config    *Config
+	Config    *config.Config
 	OpenAPI   *OpenAPI
 	Templates *Templates
 	CN        *ContentNegotiation
@@ -49,7 +51,7 @@ type Engine struct {
 
 // NewEngine builds a new Engine
 func NewEngine(configFile string, openAPIFile string, enableTrailingSlash bool, enableCORS bool) (*Engine, error) {
-	config, err := NewConfig(configFile)
+	config, err := config.NewConfig(configFile)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +59,7 @@ func NewEngine(configFile string, openAPIFile string, enableTrailingSlash bool, 
 }
 
 // NewEngineWithConfig builds a new Engine
-func NewEngineWithConfig(config *Config, openAPIFile string, enableTrailingSlash bool, enableCORS bool) *Engine {
+func NewEngineWithConfig(config *config.Config, openAPIFile string, enableTrailingSlash bool, enableCORS bool) *Engine {
 	contentNegotiation := newContentNegotiation(config.AvailableLanguages)
 	templates := newTemplates(config)
 	openAPI := newOpenAPI(config, []string{openAPIFile}, nil)

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -91,8 +93,8 @@ func TestEngine_ReverseProxy_Status204(t *testing.T) {
 
 func makeEngine(mockTargetServer *httptest.Server) (*Engine, *url.URL) {
 	engine := &Engine{
-		Config: &Config{
-			BaseURL: YAMLURL{&url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
+		Config: &config.Config{
+			BaseURL: config.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
 		},
 	}
 	targetURL, _ := url.Parse(mockTargetServer.URL)

--- a/engine/openapi.go
+++ b/engine/openapi.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	texttemplate "text/template"
 
+	gokoalaconfig "github.com/PDOK/gokoala/config"
+
 	"github.com/PDOK/gokoala/engine/util"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
@@ -38,12 +40,12 @@ type OpenAPI struct {
 	spec     *openapi3.T
 	SpecJSON []byte
 
-	config            *Config
+	config            *gokoalaconfig.Config
 	router            routers.Router
 	extraOpenAPIFiles []string
 }
 
-func newOpenAPI(config *Config, extraOpenAPIFiles []string, openAPIParams any) *OpenAPI {
+func newOpenAPI(config *gokoalaconfig.Config, extraOpenAPIFiles []string, openAPIParams any) *OpenAPI {
 	setupRequestResponseValidation()
 	ctx := context.Background()
 
@@ -127,7 +129,7 @@ func setupRequestResponseValidation() {
 //
 // The OpenAPI spec optionally provided through the CLI should be the second (after preamble) item in the
 // `files` slice since it allows the user to override other/default specs.
-func mergeSpecs(ctx context.Context, config *Config, files []string, params any) (*openapi3.T, []byte) {
+func mergeSpecs(ctx context.Context, config *gokoalaconfig.Config, files []string, params any) (*openapi3.T, []byte) {
 	loader := &openapi3.Loader{Context: ctx, IsExternalRefsAllowed: false}
 
 	if len(files) < 1 {
@@ -184,7 +186,7 @@ func newOpenAPIRouter(doc *openapi3.T) routers.Router {
 	return openAPIRouter
 }
 
-func renderOpenAPITemplate(config *Config, fileName string, params any) []byte {
+func renderOpenAPITemplate(config *gokoalaconfig.Config, fileName string, params any) []byte {
 	file := filepath.Clean(fileName)
 	parsed := texttemplate.Must(texttemplate.New(filepath.Base(file)).Funcs(globalTemplateFuncs).ParseFiles(file))
 

--- a/engine/openapi_test.go
+++ b/engine/openapi_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	gokoalaconfig "github.com/PDOK/gokoala/config"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,7 +17,7 @@ func Test_newOpenAPI(t *testing.T) {
 	}
 
 	type args struct {
-		config      *Config
+		config      *gokoalaconfig.Config
 		openAPIFile string
 	}
 	tests := []struct {
@@ -26,12 +28,12 @@ func Test_newOpenAPI(t *testing.T) {
 		{
 			name: "Test render OpenAPI spec with MINIMAL config",
 			args: args{
-				config: &Config{
+				config: &gokoalaconfig.Config{
 					Version:  "2.3.0",
 					Title:    "Test API",
 					Abstract: "Test API description",
-					BaseURL:  YAMLURL{&url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
-					OgcAPI: OgcAPI{
+					BaseURL:  gokoalaconfig.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
+					OgcAPI: gokoalaconfig.OgcAPI{
 						GeoVolumes: nil,
 						Tiles:      nil,
 						Styles:     nil,
@@ -47,14 +49,14 @@ func Test_newOpenAPI(t *testing.T) {
 		{
 			name: "Test render OpenAPI spec with OGC Tiles config",
 			args: args{
-				config: &Config{
+				config: &gokoalaconfig.Config{
 					Version:  "2.3.0",
 					Title:    "Test API",
 					Abstract: "Test API description",
-					BaseURL:  YAMLURL{&url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
-					OgcAPI: OgcAPI{
-						Tiles: &OgcAPITiles{
-							TileServer: YAMLURL{&url.URL{Scheme: "https", Host: "tiles.foobar.example", Path: "/somedataset"}},
+					BaseURL:  gokoalaconfig.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
+					OgcAPI: gokoalaconfig.OgcAPI{
+						Tiles: &gokoalaconfig.OgcAPITiles{
+							TileServer: gokoalaconfig.YAMLURL{URL: &url.URL{Scheme: "https", Host: "tiles.foobar.example", Path: "/somedataset"}},
 						},
 					},
 				},
@@ -70,13 +72,13 @@ func Test_newOpenAPI(t *testing.T) {
 		{
 			name: "Test render OpenAPI spec with OGC Styles config",
 			args: args{
-				config: &Config{
+				config: &gokoalaconfig.Config{
 					Version:  "2.3.0",
 					Title:    "Test API",
 					Abstract: "Test API description",
-					BaseURL:  YAMLURL{&url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
-					OgcAPI: OgcAPI{
-						Styles: &OgcAPIStyles{},
+					BaseURL:  gokoalaconfig.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
+					OgcAPI: gokoalaconfig.OgcAPI{
+						Styles: &gokoalaconfig.OgcAPIStyles{},
 					},
 				},
 			},
@@ -92,17 +94,17 @@ func Test_newOpenAPI(t *testing.T) {
 		{
 			name: "Test render OpenAPI spec with OGC GeoVolumes config",
 			args: args{
-				config: &Config{
+				config: &gokoalaconfig.Config{
 					Version:  "2.3.0",
 					Title:    "Test API",
 					Abstract: "Test API description",
-					BaseURL:  YAMLURL{&url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
-					OgcAPI: OgcAPI{
-						GeoVolumes: &OgcAPI3dGeoVolumes{
-							TileServer: YAMLURL{&url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
-							Collections: GeoSpatialCollections{
-								GeoSpatialCollection{ID: "feature1"},
-								GeoSpatialCollection{ID: "feature2"},
+					BaseURL:  gokoalaconfig.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
+					OgcAPI: gokoalaconfig.OgcAPI{
+						GeoVolumes: &gokoalaconfig.OgcAPI3dGeoVolumes{
+							TileServer: gokoalaconfig.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
+							Collections: gokoalaconfig.GeoSpatialCollections{
+								gokoalaconfig.GeoSpatialCollection{ID: "feature1"},
+								gokoalaconfig.GeoSpatialCollection{ID: "feature2"},
 							},
 						},
 					},
@@ -119,14 +121,14 @@ func Test_newOpenAPI(t *testing.T) {
 		{
 			name: "Test render OpenAPI spec with OGC Tiles and extra spec provided through CLI for overwrite",
 			args: args{
-				config: &Config{
+				config: &gokoalaconfig.Config{
 					Version:  "2.3.0",
 					Title:    "Test API",
 					Abstract: "Test API description",
-					BaseURL:  YAMLURL{&url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
-					OgcAPI: OgcAPI{
-						Tiles: &OgcAPITiles{
-							TileServer: YAMLURL{&url.URL{Scheme: "https", Host: "tiles.foobar.example", Path: "/somedataset"}},
+					BaseURL:  gokoalaconfig.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
+					OgcAPI: gokoalaconfig.OgcAPI{
+						Tiles: &gokoalaconfig.OgcAPITiles{
+							TileServer: gokoalaconfig.YAMLURL{URL: &url.URL{Scheme: "https", Host: "tiles.foobar.example", Path: "/somedataset"}},
 						},
 					},
 				},
@@ -145,36 +147,36 @@ func Test_newOpenAPI(t *testing.T) {
 		{
 			name: "Test render OpenAPI spec with ALL OGC APIs (common, tiles, styles, features, geovolumes)",
 			args: args{
-				config: &Config{
+				config: &gokoalaconfig.Config{
 					Version:  "2.3.0",
 					Title:    "Test API",
 					Abstract: "Test API description",
-					BaseURL:  YAMLURL{&url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
-					OgcAPI: OgcAPI{
-						GeoVolumes: &OgcAPI3dGeoVolumes{
-							TileServer: YAMLURL{&url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
-							Collections: GeoSpatialCollections{
-								GeoSpatialCollection{ID: "feature1"},
-								GeoSpatialCollection{ID: "feature2"},
+					BaseURL:  gokoalaconfig.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
+					OgcAPI: gokoalaconfig.OgcAPI{
+						GeoVolumes: &gokoalaconfig.OgcAPI3dGeoVolumes{
+							TileServer: gokoalaconfig.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
+							Collections: gokoalaconfig.GeoSpatialCollections{
+								gokoalaconfig.GeoSpatialCollection{ID: "feature1"},
+								gokoalaconfig.GeoSpatialCollection{ID: "feature2"},
 							},
 						},
-						Tiles: &OgcAPITiles{
-							TileServer: YAMLURL{&url.URL{Scheme: "https", Host: "tiles.foobar.example", Path: "/somedataset"}},
+						Tiles: &gokoalaconfig.OgcAPITiles{
+							TileServer: gokoalaconfig.YAMLURL{URL: &url.URL{Scheme: "https", Host: "tiles.foobar.example", Path: "/somedataset"}},
 						},
-						Styles: &OgcAPIStyles{},
-						Features: &OgcAPIFeatures{
-							Limit: Limit{
+						Styles: &gokoalaconfig.OgcAPIStyles{},
+						Features: &gokoalaconfig.OgcAPIFeatures{
+							Limit: gokoalaconfig.Limit{
 								Default: 20,
 								Max:     2000,
 							},
-							Collections: []GeoSpatialCollection{
+							Collections: []gokoalaconfig.GeoSpatialCollection{
 								{
 									ID: "foobar",
-									Features: &CollectionEntryFeatures{
-										Datasources: &Datasources{
-											DefaultWGS84: Datasource{
-												GeoPackage: &GeoPackage{
-													Local: &GeoPackageLocal{
+									Features: &gokoalaconfig.CollectionEntryFeatures{
+										Datasources: &gokoalaconfig.Datasources{
+											DefaultWGS84: gokoalaconfig.Datasource{
+												GeoPackage: &gokoalaconfig.GeoPackage{
+													Local: &gokoalaconfig.GeoPackageLocal{
 														File: "./examples/resources/addresses-crs84.gpkg",
 													},
 												},

--- a/engine/template.go
+++ b/engine/template.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	texttemplate "text/template"
 
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/PDOK/gokoala/engine/util"
 	sprig "github.com/go-task/slim-sprig"
 	gomarkdown "github.com/gomarkdown/markdown"
@@ -60,7 +62,7 @@ type TemplateKey struct {
 // TemplateData the data/variables passed as an argument into the template.
 type TemplateData struct {
 	// Config set during startup based on the given config file
-	Config *Config
+	Config *config.Config
 
 	// Params optional parameters not part of GoKoala's config file. You can use
 	// this to provide extra data to a template at rendering time.
@@ -142,11 +144,11 @@ type Templates struct {
 	// We prefer pre-rendered templates whenever possible. These are stored in this map.
 	RenderedTemplates map[TemplateKey][]byte
 
-	config     *Config
+	config     *config.Config
 	localizers map[language.Tag]i18n.Localizer
 }
 
-func newTemplates(config *Config) *Templates {
+func newTemplates(config *config.Config) *Templates {
 	templates := &Templates{
 		ParsedTemplates:   make(map[TemplateKey]any),
 		RenderedTemplates: make(map[TemplateKey][]byte),

--- a/ogc/common/core/main_test.go
+++ b/ogc/common/core/main_test.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/PDOK/gokoala/engine"
 	"golang.org/x/text/language"
 
@@ -34,13 +36,13 @@ func TestNewCommonCore(t *testing.T) {
 		{
 			name: "Test render templates with MINIMAL config",
 			args: args{
-				e: engine.NewEngineWithConfig(&engine.Config{
+				e: engine.NewEngineWithConfig(&config.Config{
 					Version:            "2.3.0",
 					Title:              "Test API",
 					Abstract:           "Test API description",
 					AvailableLanguages: []language.Tag{language.Dutch},
-					BaseURL:            engine.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
-					OgcAPI: engine.OgcAPI{
+					BaseURL:            config.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
+					OgcAPI: config.OgcAPI{
 						GeoVolumes: nil,
 						Tiles:      nil,
 						Styles:     nil,

--- a/ogc/common/geospatial/main_test.go
+++ b/ogc/common/geospatial/main_test.go
@@ -12,6 +12,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/PDOK/gokoala/engine"
 	"golang.org/x/text/language"
 
@@ -40,18 +42,18 @@ func TestNewCollections(t *testing.T) {
 		{
 			name: "Test render templates with Collections (using OGC GeoVolumes config, since that contains collections)",
 			args: args{
-				e: engine.NewEngineWithConfig(&engine.Config{
+				e: engine.NewEngineWithConfig(&config.Config{
 					Version:            "1.0.0",
 					Title:              "Test API",
 					Abstract:           "Test API description",
 					AvailableLanguages: []language.Tag{language.Dutch},
-					BaseURL:            engine.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
-					OgcAPI: engine.OgcAPI{
-						GeoVolumes: &engine.OgcAPI3dGeoVolumes{
-							TileServer: engine.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
-							Collections: engine.GeoSpatialCollections{
-								engine.GeoSpatialCollection{ID: "buildings"},
-								engine.GeoSpatialCollection{ID: "obstacles"},
+					BaseURL:            config.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
+					OgcAPI: config.OgcAPI{
+						GeoVolumes: &config.OgcAPI3dGeoVolumes{
+							TileServer: config.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
+							Collections: config.GeoSpatialCollections{
+								config.GeoSpatialCollection{ID: "buildings"},
+								config.GeoSpatialCollection{ID: "obstacles"},
 							},
 						},
 					},

--- a/ogc/features/datasources/geopackage/asserts.go
+++ b/ogc/features/datasources/geopackage/asserts.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/PDOK/gokoala/engine"
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/jmoiron/sqlx"
 )
 
 // assertIndexesExist asserts required indexes in the GeoPackage exists
 func assertIndexesExist(
-	configuredCollections engine.GeoSpatialCollections,
+	configuredCollections config.GeoSpatialCollections,
 	featureTableByCollectionID map[string]*featureTable,
 	db *sqlx.DB, fidColumn string) error {
 

--- a/ogc/features/datasources/geopackage/backend_cloud.go
+++ b/ogc/features/datasources/geopackage/backend_cloud.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/PDOK/gokoala/config"
+
 	cloudsqlitevfs "github.com/PDOK/go-cloud-sqlite-vfs"
-	"github.com/PDOK/gokoala/engine"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -21,7 +22,7 @@ type cloudGeoPackage struct {
 	cloudVFS *cloudsqlitevfs.VFS
 }
 
-func newCloudBackedGeoPackage(gpkg *engine.GeoPackageCloud) geoPackageBackend {
+func newCloudBackedGeoPackage(gpkg *config.GeoPackageCloud) geoPackageBackend {
 	cacheDir, err := gpkg.CacheDir()
 	if err != nil {
 		log.Fatalf("invalid cache dir, error: %v", err)

--- a/ogc/features/datasources/geopackage/backend_cloud_darwin.go
+++ b/ogc/features/datasources/geopackage/backend_cloud_darwin.go
@@ -5,7 +5,7 @@ package geopackage
 import (
 	"log"
 
-	"github.com/PDOK/gokoala/engine"
+	"github.com/PDOK/gokoala/config"
 )
 
 // Dummy implementation to make compilation on macOS work. We don't support cloud-backed
@@ -13,7 +13,7 @@ import (
 // '--allow-multiple-definition' flag. This flag is required since both the 'mattn' sqlite
 // driver and 'go-cloud-sqlite-vfs' contain a copy of the sqlite C-code, which causes
 // duplicate symbols (aka multiple definitions).
-func newCloudBackedGeoPackage(_ *engine.GeoPackageCloud) geoPackageBackend {
+func newCloudBackedGeoPackage(_ *config.GeoPackageCloud) geoPackageBackend {
 	log.Fatalf("Cloud backed GeoPackage isn't supported on darwin/macos")
 	return nil
 }

--- a/ogc/features/datasources/geopackage/backend_cloud_windows.go
+++ b/ogc/features/datasources/geopackage/backend_cloud_windows.go
@@ -5,10 +5,10 @@ package geopackage
 import (
 	"log"
 
-	"github.com/PDOK/gokoala/engine"
+	"github.com/PDOK/gokoala/config"
 )
 
-func newCloudBackedGeoPackage(_ *engine.GeoPackageCloud) geoPackageBackend {
+func newCloudBackedGeoPackage(_ *config.GeoPackageCloud) geoPackageBackend {
 	log.Fatalf("Cloud backed GeoPackage isn't supported on windows")
 	return nil
 }

--- a/ogc/features/datasources/geopackage/backend_local.go
+++ b/ogc/features/datasources/geopackage/backend_local.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/PDOK/gokoala/engine"
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/jmoiron/sqlx"
 )
 
@@ -13,7 +14,7 @@ type localGeoPackage struct {
 	db *sqlx.DB
 }
 
-func newLocalGeoPackage(gpkg *engine.GeoPackageLocal) geoPackageBackend {
+func newLocalGeoPackage(gpkg *config.GeoPackageLocal) geoPackageBackend {
 	db, err := sqlx.Open(sqliteDriverName, fmt.Sprintf("file:%s?mode=ro", gpkg.File))
 	if err != nil {
 		log.Fatalf("failed to open GeoPackage: %v", err)

--- a/ogc/features/datasources/geopackage/geopackage.go
+++ b/ogc/features/datasources/geopackage/geopackage.go
@@ -11,7 +11,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/PDOK/gokoala/engine"
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/PDOK/gokoala/engine/util"
 	"github.com/PDOK/gokoala/ogc/features/datasources"
 	"github.com/PDOK/gokoala/ogc/features/domain"
@@ -79,7 +80,7 @@ type GeoPackage struct {
 	maxBBoxSizeToUseWithRTree  int
 }
 
-func NewGeoPackage(collections engine.GeoSpatialCollections, gpkgConfig engine.GeoPackage) *GeoPackage {
+func NewGeoPackage(collections config.GeoSpatialCollections, gpkgConfig config.GeoPackage) *GeoPackage {
 	loadDriver()
 
 	g := &GeoPackage{}

--- a/ogc/features/datasources/geopackage/geopackage_test.go
+++ b/ogc/features/datasources/geopackage/geopackage_test.go
@@ -7,7 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/PDOK/gokoala/engine"
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/PDOK/gokoala/ogc/features/datasources"
 	"github.com/PDOK/gokoala/ogc/features/domain"
 	"github.com/go-spatial/geom/encoding/geojson"
@@ -23,8 +24,8 @@ func init() {
 
 func newAddressesGeoPackage() geoPackageBackend {
 	loadDriver()
-	return newLocalGeoPackage(&engine.GeoPackageLocal{
-		GeoPackageCommon: engine.GeoPackageCommon{
+	return newLocalGeoPackage(&config.GeoPackageLocal{
+		GeoPackageCommon: config.GeoPackageCommon{
 			Fid:                       "feature_id",
 			QueryTimeout:              15 * time.Second,
 			MaxBBoxSizeToUseWithRTree: 30000,
@@ -35,8 +36,8 @@ func newAddressesGeoPackage() geoPackageBackend {
 
 func newTemporalAddressesGeoPackage() geoPackageBackend {
 	loadDriver()
-	return newLocalGeoPackage(&engine.GeoPackageLocal{
-		GeoPackageCommon: engine.GeoPackageCommon{
+	return newLocalGeoPackage(&config.GeoPackageLocal{
+		GeoPackageCommon: config.GeoPackageCommon{
 			Fid:                       "feature_id",
 			QueryTimeout:              15 * time.Second,
 			MaxBBoxSizeToUseWithRTree: 30000,
@@ -47,8 +48,8 @@ func newTemporalAddressesGeoPackage() geoPackageBackend {
 
 func TestNewGeoPackage(t *testing.T) {
 	type args struct {
-		config     engine.GeoPackage
-		collection engine.GeoSpatialCollections
+		config     config.GeoPackage
+		collection config.GeoSpatialCollections
 	}
 	tests := []struct {
 		name                        string
@@ -58,18 +59,18 @@ func TestNewGeoPackage(t *testing.T) {
 		{
 			name: "open local geopackage",
 			args: args{
-				config: engine.GeoPackage{
-					Local: &engine.GeoPackageLocal{
-						GeoPackageCommon: engine.GeoPackageCommon{
+				config: config.GeoPackage{
+					Local: &config.GeoPackageLocal{
+						GeoPackageCommon: config.GeoPackageCommon{
 							Fid: "feature_id",
 						},
 						File: pwd + "/testdata/bag.gpkg",
 					},
 				},
-				collection: []engine.GeoSpatialCollection{
+				collection: []config.GeoSpatialCollection{
 					{
 						ID:       "ligplaatsen",
-						Features: &engine.CollectionEntryFeatures{},
+						Features: &config.CollectionEntryFeatures{},
 					},
 				},
 			},

--- a/ogc/features/datasources/geopackage/metadata.go
+++ b/ogc/features/datasources/geopackage/metadata.go
@@ -4,7 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/PDOK/gokoala/engine"
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/jmoiron/sqlx"
 )
 
@@ -42,7 +43,7 @@ spatialite_target_cpu() as arch`).StructScan(&m)
 // collection ID -> feature table metadata. We match each feature table to the collection ID by looking at the
 // 'identifier' column. Also in case there's no exact match between 'collection ID' and 'identifier' we use
 // the explicitly configured table name.
-func readGpkgContents(collections engine.GeoSpatialCollections, db *sqlx.DB) (map[string]*featureTable, error) {
+func readGpkgContents(collections config.GeoSpatialCollections, db *sqlx.DB) (map[string]*featureTable, error) {
 	query := `
 select
 	c.table_name, c.data_type, c.identifier, c.description, c.last_change,
@@ -112,7 +113,7 @@ func readFeatureTableInfo(db *sqlx.DB, table featureTable) error {
 	return nil
 }
 
-func hasMatchingTableName(collection engine.GeoSpatialCollection, row featureTable) bool {
+func hasMatchingTableName(collection config.GeoSpatialCollection, row featureTable) bool {
 	return collection.Features != nil && collection.Features.TableName != nil &&
 		row.Identifier == *collection.Features.TableName
 }

--- a/ogc/features/datasources/geopackage/warmup.go
+++ b/ogc/features/datasources/geopackage/warmup.go
@@ -5,14 +5,15 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/PDOK/gokoala/engine"
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/jmoiron/sqlx"
 )
 
 // warmUpFeatureTables executes a warmup query to speedup subsequent queries.
 // This encompasses traversing index(es) to fill the local cache.
 func warmUpFeatureTables(
-	configuredCollections engine.GeoSpatialCollections,
+	configuredCollections config.GeoSpatialCollections,
 	featureTableByCollectionID map[string]*featureTable,
 	db *sqlx.DB) error {
 

--- a/ogc/features/html.go
+++ b/ogc/features/html.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/PDOK/gokoala/engine"
 	"github.com/PDOK/gokoala/ogc/features/domain"
 )
@@ -42,7 +44,7 @@ type featureCollectionPage struct {
 	domain.FeatureCollection
 
 	CollectionID    string
-	Metadata        *engine.GeoSpatialCollectionMetadata
+	Metadata        *config.GeoSpatialCollectionMetadata
 	Cursor          domain.Cursors
 	PrevLink        string
 	NextLink        string
@@ -57,7 +59,7 @@ type featurePage struct {
 
 	CollectionID string
 	FeatureID    int64
-	Metadata     *engine.GeoSpatialCollectionMetadata
+	Metadata     *config.GeoSpatialCollectionMetadata
 }
 
 func (hf *htmlFeatures) features(w http.ResponseWriter, r *http.Request, collectionID string,
@@ -129,7 +131,7 @@ func (hf *htmlFeatures) feature(w http.ResponseWriter, r *http.Request, collecti
 	hf.engine.RenderAndServePage(w, r, engine.ExpandTemplateKey(featureKey, lang), pageContent, breadcrumbs)
 }
 
-func getCollectionTitle(collectionID string, metadata *engine.GeoSpatialCollectionMetadata) string {
+func getCollectionTitle(collectionID string, metadata *config.GeoSpatialCollectionMetadata) string {
 	title := collectionID
 	if metadata != nil && metadata.Title != nil {
 		title = *metadata.Title

--- a/ogc/features/main.go
+++ b/ogc/features/main.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/PDOK/gokoala/engine"
 	"github.com/PDOK/gokoala/ogc/common/geospatial"
 	ds "github.com/PDOK/gokoala/ogc/features/datasources"
@@ -27,7 +29,7 @@ const (
 )
 
 var (
-	collections            map[string]*engine.GeoSpatialCollectionMetadata
+	collections            map[string]*config.GeoSpatialCollectionMetadata
 	emptyFeatureCollection = &domain.FeatureCollection{Features: make([]*domain.Feature, 0)}
 )
 
@@ -37,8 +39,8 @@ type DatasourceKey struct {
 }
 
 type DatasourceConfig struct {
-	collections engine.GeoSpatialCollections
-	ds          engine.Datasource
+	collections config.GeoSpatialCollections
+	ds          config.Datasource
 }
 
 type Features struct {
@@ -220,8 +222,8 @@ func (f *Features) Feature() http.HandlerFunc {
 	}
 }
 
-func cacheCollectionsMetadata(e *engine.Engine) map[string]*engine.GeoSpatialCollectionMetadata {
-	result := make(map[string]*engine.GeoSpatialCollectionMetadata)
+func cacheCollectionsMetadata(e *engine.Engine) map[string]*config.GeoSpatialCollectionMetadata {
+	result := make(map[string]*config.GeoSpatialCollectionMetadata)
 	for _, collection := range e.Config.OgcAPI.Features.Collections {
 		result[collection.ID] = collection.Metadata
 	}
@@ -301,7 +303,7 @@ func configureCollectionDatasources(e *engine.Engine, result map[DatasourceKey]*
 	}
 }
 
-func newDatasource(e *engine.Engine, coll engine.GeoSpatialCollections, dsConfig engine.Datasource) ds.Datasource {
+func newDatasource(e *engine.Engine, coll config.GeoSpatialCollections, dsConfig config.Datasource) ds.Datasource {
 	var datasource ds.Datasource
 	if dsConfig.GeoPackage != nil {
 		datasource = geopackage.NewGeoPackage(coll, *dsConfig.GeoPackage)

--- a/ogc/features/openapi.go
+++ b/ogc/features/openapi.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/PDOK/gokoala/engine"
 	ds "github.com/PDOK/gokoala/ogc/features/datasources"
 )
@@ -28,7 +30,7 @@ func rebuildOpenAPIForFeatures(e *engine.Engine, datasources map[DatasourceKey]d
 	})
 }
 
-func createPropertyFiltersByCollection(config *engine.OgcAPIFeatures,
+func createPropertyFiltersByCollection(config *config.OgcAPIFeatures,
 	datasources map[DatasourceKey]ds.Datasource) (map[string][]OpenAPIPropertyFilter, error) {
 
 	result := make(map[string][]OpenAPIPropertyFilter)

--- a/ogc/features/openapi_test.go
+++ b/ogc/features/openapi_test.go
@@ -3,31 +3,32 @@ package features
 import (
 	"testing"
 
-	"github.com/PDOK/gokoala/engine"
+	"github.com/PDOK/gokoala/config"
+
 	ds "github.com/PDOK/gokoala/ogc/features/datasources"
 	"github.com/PDOK/gokoala/ogc/features/datasources/geopackage"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCreatePropertyFiltersByCollection(t *testing.T) {
-	eng, err := engine.NewConfig("ogc/features/testdata/config_features_bag.yaml")
+	eng, err := config.NewConfig("ogc/features/testdata/config_features_bag.yaml")
 	assert.NoError(t, err)
 	oaf := eng.OgcAPI.Features
 
-	eng2, err := engine.NewConfig("ogc/features/testdata/config_features_bag_invalid_filters.yaml")
+	eng2, err := config.NewConfig("ogc/features/testdata/config_features_bag_invalid_filters.yaml")
 	assert.NoError(t, err)
 	oafWithInvalidPropertyFilter := eng2.OgcAPI.Features
 
 	tests := []struct {
 		name        string
-		config      *engine.OgcAPIFeatures
+		config      *config.OgcAPIFeatures
 		datasources map[DatasourceKey]ds.Datasource
 		wantResult  map[string][]OpenAPIPropertyFilter
 		wantErr     bool
 	}{
 		{
 			name:        "Empty input",
-			config:      &engine.OgcAPIFeatures{},
+			config:      &config.OgcAPIFeatures{},
 			datasources: nil,
 			wantResult:  map[string][]OpenAPIPropertyFilter{},
 			wantErr:     false,

--- a/ogc/features/url.go
+++ b/ogc/features/url.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/PDOK/gokoala/engine"
 	"github.com/PDOK/gokoala/ogc/features/domain"
 	"github.com/go-spatial/geom"
@@ -63,8 +65,8 @@ func (c ContentCrs) IsWGS84() bool {
 type featureCollectionURL struct {
 	baseURL                   url.URL
 	params                    url.Values
-	limit                     engine.Limit
-	configuredPropertyFilters []engine.PropertyFilter
+	limit                     config.Limit
+	configuredPropertyFilters []config.PropertyFilter
 	supportsDatetime          bool
 }
 
@@ -232,7 +234,7 @@ func consolidateSRIDs(bboxSRID SRID, filterSRID SRID) (inputSRID SRID, err error
 	return inputSRID, err
 }
 
-func parseLimit(params url.Values, limitCfg engine.Limit) (int, error) {
+func parseLimit(params url.Values, limitCfg config.Limit) (int, error) {
 	limit := limitCfg.Default
 	var err error
 	if params.Get(limitParam) != "" {
@@ -311,7 +313,7 @@ func parseCrsToSRID(params url.Values, paramName string) (SRID, error) {
 }
 
 // Support simple filtering on properties: https://docs.ogc.org/is/17-069r4/17-069r4.html#_parameters_for_filtering_on_feature_properties
-func parsePropertyFilters(configuredPropertyFilters []engine.PropertyFilter, params url.Values) (map[string]string, error) {
+func parsePropertyFilters(configuredPropertyFilters []config.PropertyFilter, params url.Values) (map[string]string, error) {
 	propertyFilters := make(map[string]string)
 	for _, cpf := range configuredPropertyFilters {
 		pf := params.Get(cpf.Name)

--- a/ogc/features/url_test.go
+++ b/ogc/features/url_test.go
@@ -6,7 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/PDOK/gokoala/engine"
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/PDOK/gokoala/ogc/features/domain"
 	"github.com/go-spatial/geom"
 	"github.com/stretchr/testify/assert"
@@ -16,7 +17,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 	type fields struct {
 		baseURL   url.URL
 		params    url.Values
-		limit     engine.Limit
+		limit     config.Limit
 		dtSupport bool
 	}
 	host, _ := url.Parse("http://ogc.example")
@@ -37,7 +38,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 			fields: fields{
 				baseURL: *host,
 				params:  url.Values{},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 10,
 					Max:     20,
 				},
@@ -61,7 +62,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 					"bbox-crs": []string{"http://www.opengis.net/def/crs/EPSG/0/28992"},
 					"limit":    []string{"10000"},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 10,
 					Max:     20,
 				},
@@ -84,7 +85,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 					"bbox-crs": []string{"http://www.opengis.net/def/crs/EPSG/0/28992"},
 					"limit":    []string{"10000"},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 10,
 					Max:     20,
 				},
@@ -107,7 +108,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 					"bbox":   []string{"1,2,3,4"},
 					"limit":  []string{"10000"},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 10,
 					Max:     20,
 				},
@@ -131,7 +132,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 					"bbox":       []string{"1,2,3,4"},
 					"limit":      []string{"10000"},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 10,
 					Max:     20,
 				},
@@ -151,7 +152,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 				params: url.Values{
 					"datetime": []string{time.Time{}.Format(time.RFC3339)},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 1,
 					Max:     2,
 				},
@@ -170,7 +171,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 				params: url.Values{
 					"foo": []string{"baz"},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 10,
 					Max:     20,
 				},
@@ -190,7 +191,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 					"foo": []string{"baz"},
 					"bar": []string{"bazz"},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 10,
 					Max:     20,
 				},
@@ -209,7 +210,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 				params: url.Values{
 					"non_existent": []string{"baz"},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 10,
 					Max:     20,
 				},
@@ -226,7 +227,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 				params: url.Values{
 					"foo": []string{"baz*"},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 10,
 					Max:     20,
 				},
@@ -243,7 +244,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 				params: url.Values{
 					"foo": []string{generateRandomString(propertyFilterMaxLength + 1)},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 10,
 					Max:     20,
 				},
@@ -264,7 +265,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 					"bbox":       []string{"1,2,3,4"},
 					"limit":      []string{"10000"},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 10,
 					Max:     20,
 				},
@@ -282,7 +283,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 					"crs":      []string{"EPSG:28992"},
 					"bbox-crs": []string{"http://www.opengis.net/def/crs/EPSG/0/28992"},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 10,
 					Max:     20,
 				},
@@ -299,7 +300,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 				params: url.Values{
 					"bbox": []string{"1,2,3,4,5,6"},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 10,
 					Max:     20,
 				},
@@ -316,7 +317,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 				params: url.Values{
 					"limit": []string{"-200"},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 10,
 					Max:     20,
 				},
@@ -333,7 +334,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 				params: url.Values{
 					"datetime": []string{"2023-11-10T23:00:00Z/2023-11-15T23:00:00Z"},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 1,
 					Max:     2,
 				},
@@ -351,7 +352,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 				params: url.Values{
 					"datetime": []string{"2023-11-10T23:00:00Z/2023-11-15T23:00:00Z"},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 1,
 					Max:     2,
 				},
@@ -369,7 +370,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 				params: url.Values{
 					"filter": []string{"some CQL expression"},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 1,
 					Max:     2,
 				},
@@ -386,7 +387,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 				params: url.Values{
 					"this_param_does_not_exist_in_openapi_spec": []string{"foobar"},
 				},
-				limit: engine.Limit{
+				limit: config.Limit{
 					Default: 1,
 					Max:     2,
 				},
@@ -403,7 +404,7 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 				baseURL: tt.fields.baseURL,
 				params:  tt.fields.params,
 				limit:   tt.fields.limit,
-				configuredPropertyFilters: []engine.PropertyFilter{
+				configuredPropertyFilters: []config.PropertyFilter{
 					{
 						Name:        "foo",
 						Description: "awesome foo property to filter on",

--- a/ogc/geovolumes/main.go
+++ b/ogc/geovolumes/main.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/PDOK/gokoala/engine"
 	"github.com/PDOK/gokoala/ogc/common/geospatial"
 
@@ -131,7 +133,7 @@ func (t *ThreeDimensionalGeoVolumes) reverseProxy(w http.ResponseWriter, r *http
 	t.engine.ReverseProxy(w, r, target, prefer204, contentTypeOverwrite)
 }
 
-func (t *ThreeDimensionalGeoVolumes) idToCollection(cid string) (*engine.GeoSpatialCollection, error) {
+func (t *ThreeDimensionalGeoVolumes) idToCollection(cid string) (*config.GeoSpatialCollection, error) {
 	for _, collection := range t.engine.Config.OgcAPI.GeoVolumes.Collections {
 		if collection.ID == cid {
 			return &collection, nil

--- a/ogc/processes/main.go
+++ b/ogc/processes/main.go
@@ -3,6 +3,8 @@ package processes
 import (
 	"net/http"
 
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/PDOK/gokoala/engine"
 )
 
@@ -18,7 +20,7 @@ func NewProcesses(e *engine.Engine) *Processes {
 	return processes
 }
 
-func (p *Processes) forwarder(processServer engine.YAMLURL) http.HandlerFunc {
+func (p *Processes) forwarder(processServer config.YAMLURL) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		targetURL := *processServer.URL
 		targetURL.Path = processServer.URL.Path + r.URL.Path

--- a/ogc/styles/main_test.go
+++ b/ogc/styles/main_test.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/PDOK/gokoala/engine"
 	"golang.org/x/text/language"
 
@@ -34,33 +36,33 @@ func TestNewStyles(t *testing.T) {
 		{
 			name: "Test render templates with OGC Styles config",
 			args: args{
-				e: engine.NewEngineWithConfig(&engine.Config{
+				e: engine.NewEngineWithConfig(&config.Config{
 					Version:  "0.4.0",
 					Title:    "Test API",
 					Abstract: "Test API description",
-					Resources: &engine.Resources{
+					Resources: &config.Resources{
 						Directory: "/fakedirectory",
 					},
 					AvailableLanguages: []language.Tag{language.Dutch},
-					BaseURL:            engine.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
-					OgcAPI: engine.OgcAPI{
+					BaseURL:            config.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
+					OgcAPI: config.OgcAPI{
 						GeoVolumes: nil,
-						Tiles: &engine.OgcAPITiles{
-							TileServer: engine.YAMLURL{URL: &url.URL{Scheme: "https", Host: "tiles.foobar.example", Path: "/somedataset"}},
+						Tiles: &config.OgcAPITiles{
+							TileServer: config.YAMLURL{URL: &url.URL{Scheme: "https", Host: "tiles.foobar.example", Path: "/somedataset"}},
 							Types:      []string{"vector"},
-							SupportedSrs: []engine.SupportedSrs{
+							SupportedSrs: []config.SupportedSrs{
 								{
 									Srs: "EPSG:28992",
-									ZoomLevelRange: engine.ZoomLevelRange{
+									ZoomLevelRange: config.ZoomLevelRange{
 										Start: 12,
 										End:   12,
 									},
 								},
 							},
 						},
-						Styles: &engine.OgcAPIStyles{
+						Styles: &config.OgcAPIStyles{
 							Default: "foo",
-							SupportedStyles: []engine.StyleMetadata{
+							SupportedStyles: []config.StyleMetadata{
 								{
 									ID:    "foo",
 									Title: "bar",

--- a/ogc/tiles/main_test.go
+++ b/ogc/tiles/main_test.go
@@ -12,6 +12,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/PDOK/gokoala/config"
+
 	"github.com/PDOK/gokoala/engine"
 	"golang.org/x/text/language"
 
@@ -40,28 +42,28 @@ func TestNewTiles(t *testing.T) {
 		{
 			name: "Test render templates with OGC Tiles config",
 			args: args{
-				e: engine.NewEngineWithConfig(&engine.Config{
+				e: engine.NewEngineWithConfig(&config.Config{
 					Version:            "3.3.0",
 					Title:              "Test API",
 					Abstract:           "Test API description",
 					AvailableLanguages: []language.Tag{language.Dutch},
-					BaseURL:            engine.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
-					OgcAPI: engine.OgcAPI{
+					BaseURL:            config.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
+					OgcAPI: config.OgcAPI{
 						GeoVolumes: nil,
-						Tiles: &engine.OgcAPITiles{
-							TileServer: engine.YAMLURL{URL: &url.URL{Scheme: "https", Host: "tiles.foobar.example", Path: "/somedataset"}},
+						Tiles: &config.OgcAPITiles{
+							TileServer: config.YAMLURL{URL: &url.URL{Scheme: "https", Host: "tiles.foobar.example", Path: "/somedataset"}},
 							Types:      []string{"vector"},
-							SupportedSrs: []engine.SupportedSrs{
+							SupportedSrs: []config.SupportedSrs{
 								{
 									Srs: "EPSG:28992",
-									ZoomLevelRange: engine.ZoomLevelRange{
+									ZoomLevelRange: config.ZoomLevelRange{
 										Start: 0,
 										End:   6,
 									},
 								},
 							},
 						},
-						Styles: &engine.OgcAPIStyles{
+						Styles: &config.OgcAPIStyles{
 							Default:         "foo",
 							SupportedStyles: nil,
 						},
@@ -72,28 +74,28 @@ func TestNewTiles(t *testing.T) {
 		{
 			name: "Test render templates with OGC Tiles config and one SRS",
 			args: args{
-				e: engine.NewEngineWithConfig(&engine.Config{
+				e: engine.NewEngineWithConfig(&config.Config{
 					Version:            "3.3.0",
 					Title:              "Test API",
 					Abstract:           "Test API description",
 					AvailableLanguages: []language.Tag{language.Dutch},
-					BaseURL:            engine.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
-					OgcAPI: engine.OgcAPI{
+					BaseURL:            config.YAMLURL{URL: &url.URL{Scheme: "https", Host: "api.foobar.example", Path: "/"}},
+					OgcAPI: config.OgcAPI{
 						GeoVolumes: nil,
-						Tiles: &engine.OgcAPITiles{
-							TileServer: engine.YAMLURL{URL: &url.URL{Scheme: "https", Host: "tiles.foobar.example", Path: "/somedataset"}},
+						Tiles: &config.OgcAPITiles{
+							TileServer: config.YAMLURL{URL: &url.URL{Scheme: "https", Host: "tiles.foobar.example", Path: "/somedataset"}},
 							Types:      []string{"vector"},
-							SupportedSrs: []engine.SupportedSrs{
+							SupportedSrs: []config.SupportedSrs{
 								{
 									Srs: "EPSG:28992",
-									ZoomLevelRange: engine.ZoomLevelRange{
+									ZoomLevelRange: config.ZoomLevelRange{
 										Start: 0,
 										End:   6,
 									},
 								},
 							},
 						},
-						Styles: &engine.OgcAPIStyles{
+						Styles: &config.OgcAPIStyles{
 							Default:         "foo",
 							SupportedStyles: nil,
 						},


### PR DESCRIPTION
# Omschrijving

move `engine.Config` to its own package in order to use it in the ogcapi-operator.

adding openapi/kubebuilder markers will be done in a next PR

https://dev.kadaster.nl/jira/browse/PDOK-15461

- Refactor

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)