### PR TITLE
Use unique VFS name for each GeoPackage.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572
 	github.com/goccy/go-json v0.10.2
 	github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/mattn/go-sqlite3 v1.14.18

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd h1:PppHBegd3uPZ3Y/Iax/2mlCFJm1w4Qf/zP1MdW4ju2o=
 github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=

--- a/ogc/features/datasources/geopackage/backend_cloud.go
+++ b/ogc/features/datasources/geopackage/backend_cloud.go
@@ -7,13 +7,10 @@ import (
 	"log"
 
 	"github.com/PDOK/gokoala/config"
+	"github.com/google/uuid"
 
 	cloudsqlitevfs "github.com/PDOK/go-cloud-sqlite-vfs"
 	"github.com/jmoiron/sqlx"
-)
-
-const (
-	vfsName = "cloudbackedvfs"
 )
 
 // Cloud-Backed SQLite (CBS) GeoPackage in Azure or Google object storage
@@ -36,6 +33,7 @@ func newCloudBackedGeoPackage(gpkg *config.GeoPackageCloud) geoPackageBackend {
 		gpkg.File, gpkg.Container, gpkg.Connection)
 
 	log.Printf("connecting to %s\n", msg)
+	vfsName := uuid.New().String() // important: each geopackage must use a unique VFS name
 	vfs, err := cloudsqlitevfs.NewVFS(vfsName, gpkg.Connection, gpkg.User, gpkg.Auth,
 		gpkg.Container, cacheDir, cacheSize, gpkg.LogHTTPRequests)
 	if err != nil {


### PR DESCRIPTION
This fixes "unable to open database file" errors. This was a concurrency issue that manifests itself only under high load, when multiple GeoPackages are in use and property filters are applied.