### PR TITLE
fix json marshal inline

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"encoding/json"
+	"errors"
 	"os"
 	"path"
 	"runtime"
@@ -279,6 +281,38 @@ func TestCacheDir(t *testing.T) {
 			} else {
 				assert.Contains(t, got, *tt.gc.Cache.Path+"/test-")
 			}
+		})
+	}
+}
+
+func TestGeoSpatialCollection_Marshalling_JSON(t *testing.T) {
+	tests := []struct {
+		coll    GeoSpatialCollection
+		want    string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			coll: GeoSpatialCollection{
+				ID: "test i",
+				Metadata: &GeoSpatialCollectionMetadata{
+					Title: ptrTo("test t"),
+				},
+				GeoVolumes: &CollectionEntry3dGeoVolumes{
+					TileServerPath: ptrTo("test p"),
+				},
+			},
+			// language=json
+			want:    `{"id": "test i", "metadata": {"title": "test t"}, "tileServerPath":  "test p"}`,
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			marshalled, err := json.Marshal(tt.coll)
+			if !tt.wantErr(t, err, errors.New("json.Marshal")) {
+				return
+			}
+			assert.Equalf(t, tt.want, string(marshalled), "json.Marshal")
 		})
 	}
 }


### PR DESCRIPTION
# Omschrijving

fix json marshal inline

zover ik kan lezen / bemerken werkt json inline alleen als de structs embedded zijn

https://dev.kadaster.nl/jira/browse/PDOK-15461

## Type verandering

- Minor change (typo, formatting, version bump)
- Bugfix

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [x] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)