### PR TITLE
chore(config): consistent use of omitempty in yaml and json tags

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -835,7 +835,7 @@ type Extent struct {
 	// Projection (SRS/CRS) to be used. When none is provided WGS84 (http://www.opengis.net/def/crs/OGC/1.3/CRS84) is used.
 	// +optional
 	// +kubebuilder:validation:Pattern=`^EPSG:\d+$`
-	Srs string `yaml:"srs" json:"srs" validate:"omitempty,startswith=EPSG:"`
+	Srs string `yaml:"srs,omitempty" json:"srs,omitempty" validate:"omitempty,startswith=EPSG:"`
 
 	// Geospatial extent
 	Bbox []string `yaml:"bbox" json:"bbox"`


### PR DESCRIPTION
# Omschrijving

Een omschrijving van wat je hebt toegevoegd/veranderd:

`Extent.Srs` did not have the `omitempty` keyword on the `yaml` and `json` tags, which other `+optional` fields do.

## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Minor change (typo, formatting, version bump)
- Aanpassing van de configuratie

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [ ] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)