### PR TITLE
fix: e2e docker-compose exit too soon

### DIFF
--- a/examples/docker-compose-features-azure.yaml
+++ b/examples/docker-compose-features-azure.yaml
@@ -33,7 +33,13 @@ services:
         rclone mkdir blobs:example
         echo "upload cloud-backed sqlite/geopackage files (pre-created with blockcachevfsd CLI)"
         rclone copy /examples/resources/addresses-cloudbacked-gpkg/ blobs:example
+        touch /tmp/finished
         echo "done"
+        sleep 300 # because docker-compose --exit-code-from implies --abort-on-container-exit
+    healthcheck:
+      test: stat /tmp/finished
+      interval: 1s
+      retries: 30
 
   gokoala:
     image: gokoala:local  # run local image if available (used in CI)
@@ -42,7 +48,7 @@ services:
       dockerfile: Dockerfile
     depends_on:
       azurite-seed:
-        condition: service_completed_successfully
+        condition: service_healthy
     command: "--config-file ./examples/config_features_azure.yaml"
     volumes:
       - ./:/examples


### PR DESCRIPTION
# Omschrijving

fix docker-compose using `azurite-seed` exit code instead of `smoke-test`

## Type verandering

- Bugfix

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [x] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)