### PR TITLE
fix(spec): add license link to /collections (was only on landing page).

### DIFF
--- a/internal/ogc/common/geospatial/templates/collections.go.json
+++ b/internal/ogc/common/geospatial/templates/collections.go.json
@@ -14,6 +14,12 @@
       "type" : "text/html",
       "title" : "This document as HTML",
       "href" : "{{ $baseUrl }}/collections?f=html"
+    },
+    {
+      "rel": "license",
+      "type": "text/html",
+      "title": "{{ $cfg.License.Name }}",
+      "href": "{{ $cfg.License.URL }}"
     }
   ],
   "collections" : [

--- a/internal/ogc/features/testdata/expected_multiple_feature_tables_single_geopackage.json
+++ b/internal/ogc/features/testdata/expected_multiple_feature_tables_single_geopackage.json
@@ -11,6 +11,12 @@
       "type": "text/html",
       "title": "This document as HTML",
       "href": "http://localhost:8080/collections?f=html"
+    },
+    {
+      "rel": "license",
+      "type": "text/html",
+      "title": "CC0",
+      "href": "https://www.tldrlegal.com/license/creative-commons-cc0-1-0-universal"
     }
   ],
   "collections": [


### PR DESCRIPTION
Like in https://github.com/INSPIRE-MIF/gp-ogc-api-features/blob/master/spec/oapif-inspire-download.md#9-example-