### PR TITLE
Legend with layerid instead of layername

### DIFF
--- a/viewer/README.md
+++ b/viewer/README.md
@@ -45,7 +45,17 @@ Embed the webcomponent 'app-vectortile-view' in your web application
 </app-legend-view>
 ```
 
-see [index.html](./src/index.html) for other samples used in the [demo](https://pdok.github.io/gokoala/)
+# Legend Parameters
+
+The legend has the following parameters:
+
+- **style-url**: This is the URL to the Mapbox style that serves as input for the legend.
+
+- **title-items**: By default, the source layer names are used to name legend items. However, this parameter can be used to split legend items based on different attributes.
+
+Default layers are used for legend items. Attributes can be specified to create distinct items. For example, for the Dutch BGT, `titleItems = "type,plus_type,functie,fysiek_voorkomen,openbareruimtetype"` can be used. When `titleItems = "id"` is used, the "id" for the layer (layer name) is used to name the legend items.
+
+Legend uses is shown in the [example directory](../examples/)
 
 ## Development server
 

--- a/viewer/src/app/legend-view/legend-view.component.ts
+++ b/viewer/src/app/legend-view/legend-view.component.ts
@@ -16,8 +16,16 @@ import { NGXLogger } from 'ngx-logger'
 })
 export class LegendViewComponent implements OnInit, OnChanges {
   mapboxStyle!: MapboxStyle
+  // URL to a Mapbox style JSON endpoint
   @Input() styleUrl!: string
-  @Input() titleItems!: string //= 'type,plus_type,functie,fysiek_voorkomen'
+  /* 
+  This input is used to specify the attributes for legend items. By default, layers are used for legend items.
+  Attributes can be specified to create distinct items. For example, for the Dutch BGT, you can use 
+  titleItems = "type,plus_type,functie,fysiek_voorkomen,openbareruimtetype". 
+  Refer to: https://github.com/PDOK/vectortile-demo-viewer/blob/a8b49378bcdeef7196aabd1d34402d409421121f/projects/vectortile-demo/src/app/mapstyler/mapstyler.component.ts#L159C15-L159C75
+  If titleItems = "id" is used, the "id" (i.e., the layer name from the style JSON) is used.
+  */
+  @Input() titleItems!: string
 
   LegendItems: LegendItem[] = []
 

--- a/viewer/src/app/legend-view/legend-view.component.ts
+++ b/viewer/src/app/legend-view/legend-view.component.ts
@@ -53,8 +53,13 @@ export class LegendViewComponent implements OnInit, OnChanges {
       this.mapboxStyleService.getMapboxStyle(this.styleUrl).subscribe(style => {
         this.mapboxStyle = this.mapboxStyleService.removeRasterLayers(style)
         if (this.titleItems) {
-          const titlepart = this.titleItems.split(',')
-          this.LegendItems = this.mapboxStyleService.getItems(this.mapboxStyle, this.mapboxStyleService.customTitle, titlepart)
+          if (this.titleItems.toLocaleLowerCase() === 'id') {
+            this.LegendItems = this.mapboxStyleService.getItems(this.mapboxStyle, this.mapboxStyleService.idTitle, [])
+          } else {
+            const titlepart = this.titleItems.split(',')
+            this.LegendItems = this.mapboxStyleService.getItems(this.mapboxStyle, this.mapboxStyleService.customTitle, titlepart)
+          }
+
         } else {
           this.LegendItems = this.mapboxStyleService.getItems(this.mapboxStyle, this.mapboxStyleService.capitalizeFirstLetter, [])
         }

--- a/viewer/src/app/legend-view/legend-view.component.ts
+++ b/viewer/src/app/legend-view/legend-view.component.ts
@@ -59,7 +59,6 @@ export class LegendViewComponent implements OnInit, OnChanges {
             const titlepart = this.titleItems.split(',')
             this.LegendItems = this.mapboxStyleService.getItems(this.mapboxStyle, this.mapboxStyleService.customTitle, titlepart)
           }
-
         } else {
           this.LegendItems = this.mapboxStyleService.getItems(this.mapboxStyle, this.mapboxStyleService.capitalizeFirstLetter, [])
         }

--- a/viewer/src/app/mapbox-style.service.ts
+++ b/viewer/src/app/mapbox-style.service.ts
@@ -128,11 +128,11 @@ export class MapboxStyleService {
       if (layer.layout?.['text-field']) {
         const label = layer.layout?.['text-field'].replace('{', '').replace('}', '')
         p['' + label + ''] = label.substring(0, 6)
-        const labeltitle = titleFunction(layer['source-layer'], p, customTitlePart)
+        const labeltitle = titleFunction(layer['source-layer'], p, customTitlePart, layer['id'])
         const showLabel = label[0].toUpperCase() + label.substring(1)
         this.pushItem(labeltitle + ' ' + showLabel, layer, names, p)
       } else {
-        let title = titleFunction(layer['source-layer'], p, customTitlePart)
+        let title = titleFunction(layer['source-layer'], p, customTitlePart, layer['id'])
         this.pushItem(title, layer, names, p)
 
         let paint = layer.paint['circle-color'] as FillPattern
@@ -159,6 +159,10 @@ export class MapboxStyleService {
 
   capitalizeFirstLetter(str: string): string {
     return [...str][0].toUpperCase() + str.slice(1)
+  }
+
+  idTitle(layername: string, props: IProperties, customTitlePart: string[], id: string): string {
+    return id
   }
 
   customTitle(layername: string, props: IProperties, customTitlePart: string[]): string {

--- a/viewer/src/app/mapbox-style.service.ts
+++ b/viewer/src/app/mapbox-style.service.ts
@@ -134,8 +134,10 @@ export class MapboxStyleService {
       } else {
         let title = titleFunction(layer['source-layer'], p, customTitlePart, layer['id'])
         this.pushItem(title, layer, names, p)
-
-        let paint = layer.paint['circle-color'] as FillPattern
+        let paint: FillPattern = {} as FillPattern
+        if (layer.type == LayerType.Circle) {
+          paint = layer.paint['circle-color'] as FillPattern
+        }
         if (layer.type == LayerType.Fill) {
           paint = layer.paint['fill-color'] as FillPattern
           if (!paint) {


### PR DESCRIPTION
Minor change: 

- When `titleItems = "id"` is used, the "id" for the layer (layer name) is used to name the legend items. 
- Readme update for the legend parameters
