### PR TITLE
Duplicate datasource connections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/PDOK/gokoala
 
-go 1.22.3
+go 1.22.4
 
 require (
 	dario.cat/mergo v1.0.0

--- a/hack/crd/go.mod
+++ b/hack/crd/go.mod
@@ -1,6 +1,6 @@
 module crd
 
-go 1.22.3
+go 1.22.4
 
 require (
 	github.com/PDOK/gokoala v0.0.0

--- a/internal/engine/templates/layout.go.html
+++ b/internal/engine/templates/layout.go.html
@@ -1,9 +1,8 @@
 {{- /*gotype: github.com/PDOK/gokoala/internal/engine.TemplateData*/ -}}
 <!DOCTYPE html>
 <html lang="nl" class="h-100">
-<base href="{{ .Config.BaseURL }}/" />
-
 <head>
+    <base href="{{ .Config.BaseURL }}/" />
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
# Description

This issue caught our attention since we configured a single datasource to a remote/downloadable gpkg but noticed the gpkg was downloaded for EACH collection.

## Type of change

- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR