### PR TITLE
fix(html): Also add link on feature page + fix viewer when using next/prev in auto mode

### DIFF
--- a/internal/ogc/features/templates/feature.go.html
+++ b/internal/ogc/features/templates/feature.go.html
@@ -42,7 +42,7 @@
             <tbody>
             {{/* for map sheets collection, skip some properties pertaining to downloads, then add download button */}}
             {{ if $mapSheetProperties }}
-            {{ $skipKeys := list $mapSheetProperties.AssetURL $mapSheetProperties.Size }}
+            {{ $skipKeys := list $mapSheetProperties.Size }}
             {{ range $key, $value := .Params.Properties }}
             {{ if not (has $key $skipKeys) }}
             <tr>

--- a/internal/ogc/features/templates/features.go.html
+++ b/internal/ogc/features/templates/features.go.html
@@ -149,6 +149,7 @@
           {{ if $mapSheetProperties }}
           viewer.addEventListener('box', selectBox => {
             let newUrl = new URL(updateQueryString('bbox', selectBox.detail, true))
+            newUrl.searchParams.set('f', 'json')
             // when moving the map to load additional sheets we don't want to do a full page reload (like we
             // do when one draws a bbox). Therefor we update the browser URL + link references (like GeoJSON/JSON-FG)
             // on the page manually.

--- a/viewer/README.md
+++ b/viewer/README.md
@@ -44,19 +44,7 @@ The following values are emitted:
 - **box**
 - **activeFeature**
 
-```html
-<link rel="stylesheet" type="text/css" href="view-component/styles.css" />
-<script type="text/javascript" src="view-component/main.js"></script>
-<script type="text/javascript" src="view-component/polyfills.js"></script>
-<script type="text/javascript" src="view-component/runtime.js"></script>
-
-<app-legend-view
-  id="legendadminunit"
-  style-url="https://api.pdok.nl/kadaster/bestuurlijkegebieden/ogc/v1_0/styles/bestuurlijkegebieden_standaardvisualisatie?f=json">
-</app-legend-view>
-```
-
-## Legend Parameters
+## Legend view parameters
 
 The `<app-legend-view>` component has the following parameters:
 

--- a/viewer/src/app/feature-view/boxcontrol.ts
+++ b/viewer/src/app/feature-view/boxcontrol.ts
@@ -23,7 +23,7 @@ export function emitBox(map: Map, geometry: Geometry, boxEmitter: EventEmitter<s
 
 export class boxControl extends Control {
   /**
-   * @param boxEmitter Emitter o subscribe to bbox updates
+   * @param boxEmitter Emitter to subscribe to bbox updates
    * @param {Object} [opt_options] Control options.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/viewer/src/app/feature-view/boxcontrol.ts
+++ b/viewer/src/app/feature-view/boxcontrol.ts
@@ -23,6 +23,7 @@ export function emitBox(map: Map, geometry: Geometry, boxEmitter: EventEmitter<s
 
 export class boxControl extends Control {
   /**
+   * @param boxEmitter Emitter o subscribe to bbox updates
    * @param {Object} [opt_options] Control options.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/viewer/src/app/feature-view/fullboxcontrol.ts
+++ b/viewer/src/app/feature-view/fullboxcontrol.ts
@@ -34,8 +34,7 @@ export class fullBoxControl extends Control {
   addFullBox() {
     const map = this.getMap()!
     const extent = map.getView().calculateExtent(map.getSize())
-    const extent2 = extent // transformExtent(extent, 'EPSG:3857', 'EPSG:4326')
-    const polygon = fromExtent(extent2) as Geometry
+    const polygon = fromExtent(extent) as Geometry
     emitBox(map, polygon, this.boxEmitter)
   }
 }


### PR DESCRIPTION
# Description

- Missed feature page, also display download url there
- When viewer is in auto mode, and the user uses the next/prev link the viewer breaks. Fixed this.

## Type of change

- Minor change
- Bug fix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR