### PR TITLE
fix(sql): return error on query timeout instead of empty result

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -42,7 +42,7 @@ jobs:
       # we don't (yet) fail on benchmark results, these are just to make sure
       # the benchmarks keep working
       - name: Benchmark
-        run: go test -v ./... -bench=. -run=^# -benchmem -count=5
+        run: go test -v ./... -bench=. -run=^# -benchmem -count=1
 
       - name: Update coverage report
         uses: ncruces/go-coverage-report@v0

--- a/internal/engine/problems.go
+++ b/internal/engine/problems.go
@@ -33,12 +33,12 @@ var (
 // include sensitive information in the details string!
 func RenderProblem(kind ProblemKind, w http.ResponseWriter, details ...string) {
 	p := problem.Of(int(kind))
-	if kind == ProblemServerError { //nolint:gocritic // switch not handy here
+	if len(details) > 0 { //nolint:gocritic // switch not handy her
+		p = p.Append(problem.Detail(details[0]))
+	} else if kind == ProblemServerError {
 		p = p.Append(problem.Detail(defaultMessageServerErr))
 	} else if kind == ProblemBadGateway {
 		p = p.Append(problem.Detail(defaultMessageBadGateway))
-	} else if len(details) > 0 {
-		p = p.Append(problem.Detail(details[0]))
 	}
 	p = p.Append(problem.Custom(timestampKey, Now().UTC().Format(time.RFC3339)))
 	_, err := p.WriteTo(w)

--- a/internal/ogc/features/datasources/geopackage/geopackage.go
+++ b/internal/ogc/features/datasources/geopackage/geopackage.go
@@ -160,6 +160,9 @@ func (g *GeoPackage) GetFeatureIDs(ctx context.Context, collection string, crite
 		return nil, domain.Cursors{}, fmt.Errorf("failed to execute query '%s' error: %w", query, err)
 	}
 	defer rows.Close()
+	if queryCtx.Err() != nil {
+		return nil, domain.Cursors{}, queryCtx.Err()
+	}
 
 	featureIDs, prevNext, err := domain.MapRowsToFeatureIDs(rows)
 	if err != nil {
@@ -195,6 +198,9 @@ func (g *GeoPackage) GetFeaturesByID(ctx context.Context, collection string, fea
 		return nil, fmt.Errorf("failed to execute query '%s' error: %w", query, err)
 	}
 	defer rows.Close()
+	if queryCtx.Err() != nil {
+		return nil, queryCtx.Err()
+	}
 
 	fc := domain.FeatureCollection{}
 	fc.Features, _, err = domain.MapRowsToFeatures(rows, g.fidColumn, g.externalFidColumn, table.GeometryColumnName, readGpkgGeometry)
@@ -224,6 +230,9 @@ func (g *GeoPackage) GetFeatures(ctx context.Context, collection string, criteri
 		return nil, domain.Cursors{}, fmt.Errorf("failed to execute query '%s' error: %w", query, err)
 	}
 	defer rows.Close()
+	if queryCtx.Err() != nil {
+		return nil, domain.Cursors{}, queryCtx.Err()
+	}
 
 	var prevNext *domain.PrevNextFID
 	fc := domain.FeatureCollection{}
@@ -271,6 +280,9 @@ func (g *GeoPackage) GetFeature(ctx context.Context, collection string, featureI
 		return nil, fmt.Errorf("query '%s' failed: %w", query, err)
 	}
 	defer rows.Close()
+	if queryCtx.Err() != nil {
+		return nil, queryCtx.Err()
+	}
 
 	features, _, err := domain.MapRowsToFeatures(rows, g.fidColumn, g.externalFidColumn, table.GeometryColumnName, readGpkgGeometry)
 	if err != nil {

--- a/internal/ogc/features/main.go
+++ b/internal/ogc/features/main.go
@@ -121,7 +121,7 @@ func (f *Features) Features() http.HandlerFunc {
 				// Add filter, filter-lang
 			})
 			if err != nil {
-				handleFeatureCollectionError(w, collectionID, err)
+				handleFeaturesQueryError(w, collectionID, err)
 				return
 			}
 		} else {
@@ -143,7 +143,7 @@ func (f *Features) Features() http.HandlerFunc {
 				fc, err = datasource.GetFeaturesByID(r.Context(), collectionID, fids)
 			}
 			if err != nil {
-				handleFeatureCollectionError(w, collectionID, err)
+				handleFeaturesQueryError(w, collectionID, err)
 				return
 			}
 		}
@@ -183,15 +183,10 @@ func (f *Features) Feature() http.HandlerFunc {
 			handleCollectionNotFound(w, collectionID)
 			return
 		}
-		var featureID any
-		featureID, err := uuid.Parse(chi.URLParam(r, "featureId"))
+		featureID, err := getFeatureID(r)
 		if err != nil {
-			// fallback to numerical feature id
-			featureID, err = strconv.ParseInt(chi.URLParam(r, "featureId"), 10, 0)
-			if err != nil {
-				engine.RenderProblem(engine.ProblemBadRequest, w, "feature ID must be a UUID or number")
-				return
-			}
+			engine.RenderProblem(engine.ProblemBadRequest, w, err.Error())
+			return
 		}
 		url := featureURL{*f.engine.Config.BaseURL.URL, r.URL.Query()}
 		outputSRID, contentCrs, err := url.parse()
@@ -205,16 +200,11 @@ func (f *Features) Feature() http.HandlerFunc {
 		datasource := f.datasources[DatasourceKey{srid: outputSRID.GetOrDefault(), collectionID: collectionID}]
 		feat, err := datasource.GetFeature(r.Context(), collectionID, featureID)
 		if err != nil {
-			// log error, but sent generic message to client to prevent possible information leakage from datasource
-			msg := fmt.Sprintf("failed to retrieve feature %v in collection %s", featureID, collectionID)
-			log.Printf("%s, error: %v\n", msg, err)
-			engine.RenderProblem(engine.ProblemServerError, w, msg)
+			handleFeatureQueryError(w, collectionID, featureID, err)
 			return
 		}
 		if feat == nil {
-			msg := fmt.Sprintf("the requested feature with id: %v does not exist in collection '%s'", featureID, collectionID)
-			log.Println(msg)
-			engine.RenderProblem(engine.ProblemNotFound, w, msg)
+			handleFeatureNotFound(w, collectionID, featureID)
 			return
 		}
 
@@ -231,6 +221,19 @@ func (f *Features) Feature() http.HandlerFunc {
 			return
 		}
 	}
+}
+
+func getFeatureID(r *http.Request) (any, error) {
+	var featureID any
+	featureID, err := uuid.Parse(chi.URLParam(r, "featureId"))
+	if err != nil {
+		// fallback to numerical feature id
+		featureID, err = strconv.ParseInt(chi.URLParam(r, "featureId"), 10, 0)
+		if err != nil {
+			return nil, errors.New("feature ID must be a UUID or number")
+		}
+	}
+	return featureID, nil
 }
 
 func cacheCollectionsMetadata(e *engine.Engine) map[string]*config.GeoSpatialCollectionMetadata {
@@ -366,12 +369,29 @@ func handleCollectionNotFound(w http.ResponseWriter, collectionID string) {
 	engine.RenderProblem(engine.ProblemNotFound, w, msg)
 }
 
+func handleFeatureNotFound(w http.ResponseWriter, collectionID string, featureID any) {
+	msg := fmt.Sprintf("the requested feature with id: %v does not exist in collection '%v'", featureID, collectionID)
+	log.Println(msg)
+	engine.RenderProblem(engine.ProblemNotFound, w, msg)
+}
+
 // log error, but send generic message to client to prevent possible information leakage from datasource
-func handleFeatureCollectionError(w http.ResponseWriter, collectionID string, err error) {
+func handleFeaturesQueryError(w http.ResponseWriter, collectionID string, err error) {
 	msg := "failed to retrieve feature collection " + collectionID
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		// provide more context when user hits the query timeout
 		msg += ": querying the features took too long (timeout encountered). Simplify your request and try again, or contact support"
+	}
+	log.Printf("%s, error: %v\n", msg, err)
+	engine.RenderProblem(engine.ProblemServerError, w, msg) // don't include sensitive information in details msg
+}
+
+// log error, but sent generic message to client to prevent possible information leakage from datasource
+func handleFeatureQueryError(w http.ResponseWriter, collectionID string, featureID any, err error) {
+	msg := fmt.Sprintf("failed to retrieve feature %v in collection %s", featureID, collectionID)
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		// provide more context when user hits the query timeout
+		msg += ": querying the feature took too long (timeout encountered). Try again, or contact support"
 	}
 	log.Printf("%s, error: %v\n", msg, err)
 	engine.RenderProblem(engine.ProblemServerError, w, msg) // don't include sensitive information in details msg

--- a/internal/ogc/features/testdata/config_features_short_query_timeout.yaml
+++ b/internal/ogc/features/testdata/config_features_short_query_timeout.yaml
@@ -1,0 +1,32 @@
+---
+version: 1.0.2
+title: OGC API Features
+abstract: Query's should fail since we use a very short (nanoseconds) query timeout
+baseUrl: http://localhost:8080
+serviceIdentifier: Feats
+license:
+  name: CC0
+  url: https://www.tldrlegal.com/license/creative-commons-cc0-1-0-universal
+ogcApi:
+  features:
+    datasources:
+      defaultWGS84:
+        geopackage:
+          local:
+            file: ./examples/resources/addresses-crs84.gpkg
+            queryTimeout: 5ns
+      additional:
+        - srs: EPSG:28992
+          geopackage:
+            local:
+              file: ./examples/resources/addresses-rd.gpkg
+              queryTimeout: 5ns
+    collections:
+      - id: dutch-addresses
+        tableName: addresses  # name of the feature table (optional), when omitted collection ID is used.
+        metadata:
+          description: Query should fail since we use a very short (nanoseconds) query timeout
+          extent:
+            srs: EPSG:4326
+            interval: [ "\"1970-01-01T00:00:00Z\"", "null" ]
+

--- a/internal/ogc/features/testdata/expected_empty_feature_collection.json
+++ b/internal/ogc/features/testdata/expected_empty_feature_collection.json
@@ -1,0 +1,26 @@
+{
+  "type": "FeatureCollection",
+  "timeStamp": "2000-01-01T00:00:00Z",
+  "links": [
+    {
+      "rel": "self",
+      "title": "This document as GeoJSON",
+      "type": "application/geo+json",
+      "href": "http://localhost:8080/collections/foo/items?f=json&straatnaam=doesnotexist"
+    },
+    {
+      "rel": "alternate",
+      "title": "This document as JSON-FG",
+      "type": "application/vnd.ogc.fg+json",
+      "href": "http://localhost:8080/collections/foo/items?f=jsonfg&straatnaam=doesnotexist"
+    },
+    {
+      "rel": "alternate",
+      "title": "This document as HTML",
+      "type": "text/html",
+      "href": "http://localhost:8080/collections/foo/items?f=html&straatnaam=doesnotexist"
+    }
+  ],
+  "features": [],
+  "numberReturned": 0
+}

--- a/internal/ogc/features/testdata/expected_query_timeout_feature.json
+++ b/internal/ogc/features/testdata/expected_query_timeout_feature.json
@@ -1,0 +1,6 @@
+{
+  "detail": "failed to retrieve feature 4030 in collection dutch-addresses: querying the feature took too long (timeout encountered). Try again, or contact support",
+  "status": 500,
+  "timeStamp": "2000-01-01T00:00:00Z",
+  "title": "Internal Server Error"
+}

--- a/internal/ogc/features/testdata/expected_query_timeout_features.json
+++ b/internal/ogc/features/testdata/expected_query_timeout_features.json
@@ -1,0 +1,6 @@
+{
+  "detail": "failed to retrieve feature collection dutch-addresses: querying the features took too long (timeout encountered). Simplify your request and try again, or contact support",
+  "status": 500,
+  "timeStamp": "2000-01-01T00:00:00Z",
+  "title": "Internal Server Error"
+}


### PR DESCRIPTION
# Description

Long query's should return an error instead of empty result.

## Type of change

- Improvement of existing feature
- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR