### PR TITLE
fix(tiles): few fixes around collection-level OGC API Tiles:

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -940,13 +940,19 @@ type PropertyFilter struct {
 
 // +kubebuilder:object:generate=true
 type Tiles struct {
-	// Reference to the server (or object storage) hosting the tiles
+	// Reference to the server (or object storage) hosting the tiles.
+	// Note: Only marked as optional in CRD to support top-level OR collection-level tiles
+	// +optional
 	TileServer URL `yaml:"tileServer" json:"tileServer" validate:"required"`
 
 	// Could be 'vector' and/or 'raster' to indicate the types of tiles offered
+	// Note: Only marked as optional in CRD to support top-level OR collection-level tiles
+	// +optional
 	Types []TilesType `yaml:"types" json:"types" validate:"required"`
 
 	// Specifies in what projections (SRS/CRS) the tiles are offered
+	// Note: Only marked as optional in CRD to support top-level OR collection-level tiles
+	// +optional
 	SupportedSrs []SupportedSrs `yaml:"supportedSrs" json:"supportedSrs" validate:"required,dive"`
 
 	// Optional template to the vector tiles on the tileserver. Defaults to {tms}/{z}/{x}/{y}.pbf.

--- a/internal/ogc/common/core/templates/conformance.go.html
+++ b/internal/ogc/common/core/templates/conformance.go.html
@@ -194,10 +194,12 @@
                         <td><a href="http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tilesets-list" target="_blank" aria-label="{{ i18n "To" }} conf/tilesets-list {{ i18n "Definition" }}">http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tilesets-list</a></td>
                         <td>{{ i18n "Standard" }}</td>
                     </tr>
+                    {{ if .Config.OgcAPI.Tiles.DatasetTiles }}
                     <tr>
                         <td><a href="http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/dataset-tilesets" target="_blank" aria-label="{{ i18n "To" }} conf/dataset-tilesets {{ i18n "Definition" }}">http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/dataset-tilesets</a></td>
                         <td>{{ i18n "Standard" }}</td>
                     </tr>
+                    {{ end }}
                     {{ if .Config.OgcAPI.Tiles.Collections }}
                         <tr>
                             <td><a href="http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/geodata-tilesets" target="_blank" aria-label="{{ i18n "To" }} conf/geodata-tilesets {{ i18n "Definition" }}">http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/geodata-tilesets</a></td>

--- a/internal/ogc/common/core/templates/conformance.go.json
+++ b/internal/ogc/common/core/templates/conformance.go.json
@@ -53,7 +53,9 @@
       ,"http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/core"
       ,"http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tileset"
       ,"http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tilesets-list"
+      {{ if .Config.OgcAPI.Tiles.DatasetTiles }}
       ,"http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/dataset-tilesets"
+      {{ end }}
       {{ if .Config.OgcAPI.Tiles.Collections }}
         ,"http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/geodata-tilesets"
       {{ end }}

--- a/internal/ogc/common/core/templates/landing-page.go.html
+++ b/internal/ogc/common/core/templates/landing-page.go.html
@@ -111,7 +111,7 @@
     </div>
     {{ end }}
 
-    {{ if .Config.OgcAPI.Tiles }}
+    {{ if and .Config.OgcAPI.Tiles .Config.OgcAPI.Tiles.DatasetTiles }}
     <div class="col-md-4 col-sm-12">
         <div class="card h-100">
             <h2 class="card-header h5">

--- a/internal/ogc/common/core/templates/landing-page.go.json
+++ b/internal/ogc/common/core/templates/landing-page.go.json
@@ -49,7 +49,7 @@
       "href": "{{ .Config.BaseURL }}/styles"
     }
     {{ end }}
-    {{ if .Config.OgcAPI.Tiles }}
+    {{ if and .Config.OgcAPI.Tiles .Config.OgcAPI.Tiles.DatasetTiles }}
     ,
     {
       "rel": "http://www.opengis.net/def/rel/ogc/1.0/tilesets-vector",

--- a/internal/ogc/tiles/main.go
+++ b/internal/ogc/tiles/main.go
@@ -217,9 +217,11 @@ func renderTileMatrixTemplates(e *engine.Engine) {
 func renderTilesTemplates(e *engine.Engine, collection *config.GeoSpatialCollection, data templateData) {
 
 	var breadcrumbs []engine.Breadcrumb
+	path := tilesPath
 	collectionID := ""
 	if collection != nil {
 		collectionID = collection.ID
+		path = g.CollectionsPath + "/" + collectionID + tilesPath
 
 		breadcrumbs = collectionsBreadcrumb
 		breadcrumbs = append(breadcrumbs, []engine.Breadcrumb{
@@ -236,7 +238,7 @@ func renderTilesTemplates(e *engine.Engine, collection *config.GeoSpatialCollect
 		breadcrumbs = tilesBreadcrumbs
 	}
 
-	e.RenderTemplatesWithParams(tilesPath,
+	e.RenderTemplatesWithParams(path,
 		data,
 		breadcrumbs,
 		engine.NewTemplateKeyWithName(templatesDir+"tiles.go.json", collectionID),
@@ -252,7 +254,7 @@ func renderTilesTemplates(e *engine.Engine, collection *config.GeoSpatialCollect
 			},
 		}...)
 
-		path := tilesPath + "/" + projection
+		path = tilesPath + "/" + projection
 		if collection != nil {
 			path = g.CollectionsPath + "/" + collectionID + tilesPath + "/" + projection
 		}


### PR DESCRIPTION
- fix landing/conformance page to not include dataset tiles when only using collection-level tiles
- made some fields optional in CRD, since we're inlining a struct in the generated YAML/JSON.

## Type of change

- Bugfix

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR