### PR TITLE
refactor(filters): Consolidate property filters logic to a single func.

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -31,10 +31,15 @@ jobs:
         run: go build -v ./...
 
       - name: Unit Test
-        run: |
-          go test -v -shuffle=on -coverpkg "$(go list || go list -m | head -1)/..." -coverprofile cover.out.tmp ./...
-          # remove generate code from coverage results
-          grep -v "zz_generated" cover.out.tmp > cover.out
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 2
+          retry_on: error
+          command: |
+            go test -v -shuffle=on -coverpkg "$(go list || go list -m | head -1)/..." -coverprofile cover.out.tmp ./...
+            # remove generate code from coverage results
+            grep -v "zz_generated" cover.out.tmp > cover.out
 
       - name: Test generating example CRD
         run: hack/generate-crd.sh

--- a/internal/ogc/features/datasources/datasource.go
+++ b/internal/ogc/features/datasources/datasource.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-spatial/geom"
 )
 
-// Datasource holds all Features for a single object type in a specific projection.
+// Datasource holds all Features for a single object type in a specific projection/CRS.
 // This abstraction allows the rest of the system to stay datastore agnostic.
 type Datasource interface {
 
@@ -29,7 +29,8 @@ type Datasource interface {
 	// GetFeatureTableMetadata returns metadata about a feature table associated with the given collection
 	GetFeatureTableMetadata(collection string) (FeatureTableMetadata, error)
 
-	// GetPropertyFiltersWithAllowedValues returns configured property filters for the given collection enriched with allowed values
+	// GetPropertyFiltersWithAllowedValues returns configured property filters for the given collection enriched with allowed values.
+	// When enrichments don't apply the returned result should still contain all property filters as specified in the (YAML) config.
 	GetPropertyFiltersWithAllowedValues(collection string) PropertyFiltersWithAllowedValues
 
 	// Close closes (connections to) the datasource gracefully

--- a/internal/ogc/features/url_test.go
+++ b/internal/ogc/features/url_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/PDOK/gokoala/config"
+	"github.com/PDOK/gokoala/internal/ogc/features/datasources"
 
 	"github.com/PDOK/gokoala/internal/ogc/features/domain"
 	"github.com/go-spatial/geom"
@@ -472,14 +473,14 @@ func Test_featureCollectionURL_parseParams(t *testing.T) {
 				baseURL: tt.fields.baseURL,
 				params:  tt.fields.params,
 				limit:   tt.fields.limit,
-				configuredPropertyFilters: []config.PropertyFilter{
-					{
-						Name:        "foo",
-						Description: "awesome foo property to filter on",
+				configuredPropertyFilters: map[string]datasources.PropertyFilterWithAllowedValues{
+					"foo": {
+						PropertyFilter: config.PropertyFilter{Name: "foo", Description: "awesome foo property to filter on"},
+						AllowedValues:  nil,
 					},
-					{
-						Name:        "bar",
-						Description: "even more awesome bar property to filter on",
+					"bar": {
+						PropertyFilter: config.PropertyFilter{Name: "bar", Description: "even more awesome bar property to filter on"},
+						AllowedValues:  nil,
 					},
 				},
 				supportsDatetime: tt.fields.dtSupport,


### PR DESCRIPTION
# Description

Instead of having both "configurePropertyFiltersWithAllowedValues" and "getConfiguredPropertyFilters".

## Type of change

- Refactoring

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR