### PR TITLE
perf: rtree/btree threshold, reduce from 30K to 8K + fix timeout handling

### DIFF
--- a/config/collections.go
+++ b/config/collections.go
@@ -66,6 +66,11 @@ func (c *GeoSpatialCollection) UnmarshalJSON(b []byte) error {
 	return yaml.Unmarshal(b, c)
 }
 
+// HasDateTime true when collection has temporal support, false otherwise
+func (c *GeoSpatialCollection) HasDateTime() bool {
+	return c.Metadata != nil && c.Metadata.TemporalProperties != nil
+}
+
 // +kubebuilder:object:generate=true
 type GeoSpatialCollectionMetadata struct {
 	// Human friendly title of this collection. When no title is specified the collection ID is used.

--- a/config/ogcapi_features.go
+++ b/config/ogcapi_features.go
@@ -161,10 +161,10 @@ type GeoPackageCommon struct {
 	// +optional
 	QueryTimeout Duration `yaml:"queryTimeout,omitempty" json:"queryTimeout,omitempty" validate:"required" default:"15s"`
 
-	// ADVANCED SETTING. When the number of features in a bbox stay within the given value use an RTree index, otherwise use a BTree index
-	// +kubebuilder:default=30000
+	// ADVANCED SETTING. When the number of features in a bbox stay within the given value use an RTree index, otherwise use a BTree index.
+	// +kubebuilder:default=8000
 	// +optional
-	MaxBBoxSizeToUseWithRTree int `yaml:"maxBBoxSizeToUseWithRTree,omitempty" json:"maxBBoxSizeToUseWithRTree,omitempty" validate:"required" default:"30000"`
+	MaxBBoxSizeToUseWithRTree int `yaml:"maxBBoxSizeToUseWithRTree,omitempty" json:"maxBBoxSizeToUseWithRTree,omitempty" validate:"required" default:"8000"`
 
 	// ADVANCED SETTING. Sets the SQLite "cache_size" pragma which determines how many pages are cached in-memory.
 	// See https://sqlite.org/pragma.html#pragma_cache_size for details.

--- a/internal/ogc/features/domain/mapper_test.go
+++ b/internal/ogc/features/domain/mapper_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -98,8 +99,7 @@ func TestMapColumnsToFeature(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prevNextID, err := mapColumnsToFeature(tt.firstRow, tt.feature, tt.columns, tt.values,
-				tt.fidColumn, tt.externalFidCol, tt.geomColumn, tt.mapGeom, nil)
+			prevNextID, err := mapColumnsToFeature(context.Background(), tt.firstRow, tt.feature, tt.columns, tt.values, tt.fidColumn, tt.externalFidCol, tt.geomColumn, tt.mapGeom, nil)
 
 			if tt.expectedError != nil {
 				assert.Nil(t, prevNextID)

--- a/internal/ogc/features/main.go
+++ b/internal/ogc/features/main.go
@@ -94,7 +94,7 @@ func (f *Features) Features() http.HandlerFunc {
 			return
 		}
 		url := featureCollectionURL{*cfg.BaseURL.URL, r.URL.Query(), cfg.OgcAPI.Features.Limit,
-			f.configuredPropertyFilters[collectionID], hasDateTime(collection)}
+			f.configuredPropertyFilters[collectionID], collection.HasDateTime()}
 		encodedCursor, limit, inputSRID, outputSRID, contentCrs, bbox, referenceDate, propertyFilters, err := url.parse()
 		if err != nil {
 			engine.RenderProblem(engine.ProblemBadRequest, w, err.Error())
@@ -402,15 +402,11 @@ func querySingleDatasource(input domain.SRID, output domain.SRID, bbox *geom.Ext
 
 func getTemporalCriteria(collection config.GeoSpatialCollection, referenceDate time.Time) ds.TemporalCriteria {
 	var temporalCriteria ds.TemporalCriteria
-	if hasDateTime(collection) {
+	if collection.HasDateTime() {
 		temporalCriteria = ds.TemporalCriteria{
 			ReferenceDate:     referenceDate,
 			StartDateProperty: collection.Metadata.TemporalProperties.StartDate,
 			EndDateProperty:   collection.Metadata.TemporalProperties.EndDate}
 	}
 	return temporalCriteria
-}
-
-func hasDateTime(collection config.GeoSpatialCollection) bool {
-	return collection.Metadata != nil && collection.Metadata.TemporalProperties != nil
 }


### PR DESCRIPTION
# Description

- reduce chance of timeouts by finetuning RTree/BTree threshold
- when timeout occurs return proper error (also included row mapping)

## Type of change

- Configuration change
- Bugfix

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR