### PR TITLE
fix(gpkg): check table_name instead of identifier

### DIFF
--- a/internal/ogc/features/datasources/geopackage/metadata.go
+++ b/internal/ogc/features/datasources/geopackage/metadata.go
@@ -76,7 +76,7 @@ where
 		}
 
 		for _, collection := range collections {
-			if row.Identifier == collection.ID {
+			if row.TableName == collection.ID {
 				result[collection.ID] = &row
 			} else if hasMatchingTableName(collection, row) {
 				result[collection.ID] = &row
@@ -160,5 +160,5 @@ func readFeatureTableInfo(db *sqlx.DB, table featureTable) error {
 
 func hasMatchingTableName(collection config.GeoSpatialCollection, row featureTable) bool {
 	return collection.Features != nil && collection.Features.TableName != nil &&
-		row.Identifier == *collection.Features.TableName
+		row.TableName == *collection.Features.TableName
 }


### PR DESCRIPTION
# Description

When comparing collections to the `gpkg_contents` table, compare the collection's `ID` or `TableName` against the `table_name`
column instead of the `identifier` column, as the latter may contain a human-readable text (shorter, or including punctuation).

## Type of change

(Remove irrelevant options)

- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR