### PR TITLE
fix(html): avoid wrapping keywords in the middle of a word

### DIFF
--- a/internal/ogc/common/core/templates/landing-page.go.html
+++ b/internal/ogc/common/core/templates/landing-page.go.html
@@ -45,7 +45,7 @@
                     <td class="w-25 text-nowrap fw-bold">
                         {{ i18n "Keywords" }}
                     </td>
-                    <td>
+                    <td class="text-break">
                         {{ .Config.Keywords | join ", " }}
                     </td>
                 </tr>


### PR DESCRIPTION
# Description

When a long list of keywords was supplied, the word-wrap caused breaking of keywords in arbitrary places, often in the middle of words. This is fixed by using Bootstrap's `.text-break` class.

## Type of change

(Remove irrelevant options)

- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR