### PR TITLE
fix viewer shouldnt convert url to lowercase

### DIFF
--- a/viewer/src/app/feature-view/feature-view.component.ts
+++ b/viewer/src/app/feature-view/feature-view.component.ts
@@ -343,7 +343,7 @@ export class FeatureViewComponent implements OnChanges, AfterViewInit {
             const featureId = feature.getId()
             if (featureId) {
               const items = 'items'
-              const itemsUrl = this.itemsUrl.toLowerCase()
+              const itemsUrl = this.itemsUrl
               const currentUrl = new URL(itemsUrl.substring(0, itemsUrl.indexOf(items) + items.length))
               const link = currentUrl.protocol + '//' + currentUrl.host + currentUrl.pathname + '/' + featureId
               tooltipContent.innerHTML = '<a href="' + link + '">' + featureId + '</a>'


### PR DESCRIPTION
# Description

fix viewer shouldnt convert url to lowercase
e.g. collection IDs are case sensitive and sometimes contain upper case chars

PDOK-17366

## Type of change

- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR