### PR TITLE
fix(html): correctly break keywords on collection page

### DIFF
--- a/internal/ogc/common/geospatial/templates/collection.go.html
+++ b/internal/ogc/common/geospatial/templates/collection.go.html
@@ -67,7 +67,7 @@
                     <td class="w-25 text-nowrap fw-bold">
                         {{ i18n "Keywords" }}:
                     </td>
-                    <td>
+                    <td class="text-break">
                         {{ .Params.Metadata.Keywords | join ", " }}
                     </td>
                 </tr>


### PR DESCRIPTION
# Description

Same as landing page, keywords are breaking incorrectly on the collection overview page.

## Type of change

(Remove irrelevant options)

- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR