### PR TITLE
put href prop before _shortest_ similarly named key

### DIFF
--- a/internal/ogc/features/domain/props.go
+++ b/internal/ogc/features/domain/props.go
@@ -69,7 +69,7 @@ func (p *FeatureProperties) SetRelation(key string, value any, existingKeyPrefix
 	p.moveKeyBeforePrefix(key, existingKeyPrefix)
 }
 
-// moveKeyBeforePrefix best-effort algorithm to place the feature relation BEFORE any similarly named keys.
+// moveKeyBeforePrefix best-effort algorithm to place the feature relation BEFORE the first shortest of any similarly named keys.
 // For example, places "building.href" before "building_fk" or "building_fid".
 func (p *FeatureProperties) moveKeyBeforePrefix(key string, keyPrefix string) {
 	if p.unordered != nil {
@@ -78,8 +78,10 @@ func (p *FeatureProperties) moveKeyBeforePrefix(key string, keyPrefix string) {
 	var existingKey string
 	for pair := p.ordered.Oldest(); pair != nil; pair = pair.Next() {
 		if strings.HasPrefix(pair.Key, keyPrefix) {
+			if existingKey != "" && len(existingKey) <= len(pair.Key) {
+				continue
+			}
 			existingKey = pair.Key
-			break
 		}
 	}
 	if existingKey != "" {


### PR DESCRIPTION
# Description

put href prop before _shortest_ similarly named key

PDOK-17329

## Type of change

- Minor change (typo, formatting, version bump)

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works -> local visual inspection
- [ ] There's no sensitive information like credentials in my PR