### PR TITLE
fix: for OGC API Tiles validator findings [merge in januari]

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -34,19 +34,31 @@ jobs:
             --name gokoala \
             gokoala:local --config-file /examples/config_all.yaml
 
-      # E2E Test
+      # E2E Test (Cypress)
       - name: E2E Test => Cypress
         uses: cypress-io/github-action@v6
         with:
           working-directory: ./tests
           browser: chrome
 
-      # E2E Test
+      # E2E Test (Features conformance)
       - name: E2E Test => OGC API Features Conformance Validation
         run: |
           sleep 5
           docker run --net=host -t -v "$(pwd):/mnt" \
             docker.io/pdok/ets-ogcapi-features10-docker:latest \
+            http://localhost:8080 \
+            --generateHtmlReport true \
+            --outputDir /mnt/output \
+            --exitOnFail \
+            --prettyPrint
+
+      # E2E Test (Tiles conformance)
+      - name: E2E Test => OGC API Tiles Conformance Validation
+        run: |
+          sleep 5
+          docker run --net=host -t -v "$(pwd):/mnt" \
+            docker.io/pdok/ets-ogcapi-tiles10-docker:latest \
             http://localhost:8080 \
             --generateHtmlReport true \
             --outputDir /mnt/output \

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -130,7 +130,7 @@ func Test_newRouter(t *testing.T) {
 			log.Print(recorder.Body.String()) // to ease debugging
 			switch {
 			case strings.HasSuffix(tt.apiCall, "json"):
-				assert.JSONEq(t, recorder.Body.String(), string(expectedBody))
+				assert.JSONEq(t, string(expectedBody), recorder.Body.String())
 			case strings.HasSuffix(tt.apiCall, "html") || strings.HasSuffix(tt.apiCall, "xml"):
 				assert.Contains(t, normalize(recorder.Body.String()), normalize(string(expectedBody)))
 			default:

--- a/examples/config_all.yaml
+++ b/examples/config_all.yaml
@@ -70,6 +70,10 @@ ogcApi:
         zoomLevelRange:
           start: 14
           end: 14
+      - srs: EPSG:3857
+        zoomLevelRange:
+          start: 17
+          end: 17
     collections:
       # geodata tiles (collection-level tiles)
       - id: addresses  # same collection as the geovolumes/features
@@ -86,6 +90,10 @@ ogcApi:
             zoomLevelRange:
               start: 14
               end: 14
+          - srs: EPSG:3857
+            zoomLevelRange:
+              start: 17
+              end: 17
 
   features:
     datasources:

--- a/internal/engine/contentnegotiation.go
+++ b/internal/engine/contentnegotiation.go
@@ -84,6 +84,7 @@ func newContentNegotiation(availableLanguages []config.Language) *ContentNegotia
 		contenttype.NewMediaType(MediaTypeMVT),
 		contenttype.NewMediaType(MediaTypeMapboxStyle),
 		contenttype.NewMediaType(MediaTypeSLD),
+		contenttype.NewMediaType(MediaTypeOpenAPI),
 	}
 
 	formatsByMediaType := map[string]string{
@@ -171,7 +172,7 @@ func (cn *ContentNegotiation) getFormatFromQueryParam(req *http.Request) string 
 func (cn *ContentNegotiation) getFormatFromAcceptHeader(req *http.Request) string {
 	accepted, _, err := contenttype.GetAcceptableMediaType(req, cn.availableMediaTypes)
 	if err != nil {
-		log.Printf("Failed to parse Accept header: %v. Continuing\n", err)
+		log.Printf("Failed to parse Accept header: %v. Continuing\nValue(s) provided: %v\n", err, req.Header.Values("Accept"))
 		return ""
 	}
 	return cn.formatsByMediaType[accepted.String()]

--- a/internal/engine/contentnegotiation.go
+++ b/internal/engine/contentnegotiation.go
@@ -172,7 +172,7 @@ func (cn *ContentNegotiation) getFormatFromQueryParam(req *http.Request) string 
 func (cn *ContentNegotiation) getFormatFromAcceptHeader(req *http.Request) string {
 	accepted, _, err := contenttype.GetAcceptableMediaType(req, cn.availableMediaTypes)
 	if err != nil {
-		log.Printf("Failed to parse Accept header: %v. Continuing\nValue(s) provided: %v\n", err, req.Header.Values("Accept"))
+		log.Printf("Failed to parse Accept header: %v. Continuing\n", err)
 		return ""
 	}
 	return cn.formatsByMediaType[accepted.String()]

--- a/internal/engine/templates/openapi/tiles.go.json
+++ b/internal/engine/templates/openapi/tiles.go.json
@@ -23,7 +23,7 @@
           "Tiling Schemes"
         ],
         "summary": "Retrieve the list of available tiling schemes (tile matrix sets)",
-        "operationId": "getTileMatrixSetsList",
+        "operationId": "getTileMatrixSetsList.dataset.vector.getTileSetsList",
         "parameters": [
           {
             "$ref": "#/components/parameters/f-metadata"
@@ -43,7 +43,7 @@
           "Tiling Schemes"
         ],
         "summary": "Retrieve the definition of the specified tiling scheme (tile matrix set)",
-        "operationId": "getTileMatrixSet",
+        "operationId": "getTileMatrixSet.dataset.vector.getTileSet",
         "parameters": [
           {
             "$ref": "#/components/parameters/tileMatrixSetId"
@@ -67,7 +67,7 @@
           "Vector Tiles"
         ],
         "summary": "Retrieve a list of available vector tilesets for the whole dataset",
-        "operationId": "{{ $coll.ID }}.getVectorTiles",
+        "operationId": "{{ $coll.ID }}.getVectorTiles.collection.vector.getTileSetsList",
         "parameters": [
           {
             "$ref": "#/components/parameters/f-metadata"
@@ -87,7 +87,7 @@
           "Vector Tiles"
         ],
         "summary": "Retrieve the vector tileset metadata for the whole dataset and the specified tiling scheme (tile matrix set)",
-        "operationId": "{{ $coll.ID }}.getVectorTilesMetadata",
+        "operationId": "{{ $coll.ID }}.getVectorTilesMetadata.collection.vector.getTileSet",
         "parameters": [
           {
             "$ref": "#/components/parameters/tileMatrixSetId"
@@ -110,7 +110,7 @@
           "Vector Tiles"
         ],
         "summary": "Retrieve a vector tile from the dataset.",
-        "operationId": "{{ $coll.ID }}.getTile",
+        "operationId": "{{ $coll.ID }}.getTile.collection.vector.getTile",
         "parameters": [
           {
             "$ref": "#/components/parameters/tileMatrix"
@@ -147,7 +147,7 @@
           "Vector Tiles"
         ],
         "summary": "Retrieve a list of available vector tilesets for the specified collection",
-        "operationId": "getVectorTiles",
+        "operationId": "getVectorTiles.dataset.vector.getTileSetsList",
         "parameters": [
           {
             "$ref": "#/components/parameters/f-metadata"
@@ -167,7 +167,7 @@
           "Vector Tiles"
         ],
         "summary": "Retrieve the vector tileset metadata for the specified collection and tiling scheme (tile matrix set)",
-        "operationId": "getVectorTilesMetadata",
+        "operationId": "getVectorTilesMetadata.dataset.vector.getTileSet",
         "parameters": [
           {
             "$ref": "#/components/parameters/tileMatrixSetId"
@@ -190,7 +190,7 @@
           "Vector Tiles"
         ],
         "summary": "Retrieve a vector tile from a collection",
-        "operationId": "getTile",
+        "operationId": "getTile.dataset.vector.getTile",
         "parameters": [
           {
             "$ref": "#/components/parameters/tileMatrix"

--- a/internal/engine/templates/openapi/tiles.go.json
+++ b/internal/engine/templates/openapi/tiles.go.json
@@ -23,7 +23,7 @@
           "Tiling Schemes"
         ],
         "summary": "Retrieve the list of available tiling schemes (tile matrix sets)",
-        "operationId": "getTileMatrixSetsList.dataset.vector.getTileSetsList",
+        "operationId": "tileMatrixSets.dataset.vector.getTileSetsList",
         "parameters": [
           {
             "$ref": "#/components/parameters/f-metadata"
@@ -43,7 +43,7 @@
           "Tiling Schemes"
         ],
         "summary": "Retrieve the definition of the specified tiling scheme (tile matrix set)",
-        "operationId": "getTileMatrixSet.dataset.vector.getTileSet",
+        "operationId": "tileMatrixSets.dataset.vector.getTileSet",
         "parameters": [
           {
             "$ref": "#/components/parameters/tileMatrixSetId"
@@ -67,7 +67,7 @@
           "Vector Tiles"
         ],
         "summary": "Retrieve a list of available vector tilesets for the whole dataset",
-        "operationId": "{{ $coll.ID }}.getVectorTiles.collection.vector.getTileSetsList",
+        "operationId": "{{ $coll.ID }}.collection.vector.getTileSetsList",
         "parameters": [
           {
             "$ref": "#/components/parameters/f-metadata"
@@ -87,7 +87,7 @@
           "Vector Tiles"
         ],
         "summary": "Retrieve the vector tileset metadata for the whole dataset and the specified tiling scheme (tile matrix set)",
-        "operationId": "{{ $coll.ID }}.getVectorTilesMetadata.collection.vector.getTileSet",
+        "operationId": "{{ $coll.ID }}.collection.vector.getTileSet",
         "parameters": [
           {
             "$ref": "#/components/parameters/tileMatrixSetId"
@@ -110,7 +110,7 @@
           "Vector Tiles"
         ],
         "summary": "Retrieve a vector tile from the dataset.",
-        "operationId": "{{ $coll.ID }}.getTile.collection.vector.getTile",
+        "operationId": "{{ $coll.ID }}.collection.vector.getTile",
         "parameters": [
           {
             "$ref": "#/components/parameters/tileMatrix"
@@ -147,7 +147,7 @@
           "Vector Tiles"
         ],
         "summary": "Retrieve a list of available vector tilesets for the specified collection",
-        "operationId": "getVectorTiles.dataset.vector.getTileSetsList",
+        "operationId": "tiles.dataset.vector.getTileSetsList",
         "parameters": [
           {
             "$ref": "#/components/parameters/f-metadata"
@@ -167,7 +167,7 @@
           "Vector Tiles"
         ],
         "summary": "Retrieve the vector tileset metadata for the specified collection and tiling scheme (tile matrix set)",
-        "operationId": "getVectorTilesMetadata.dataset.vector.getTileSet",
+        "operationId": "tiles.dataset.vector.getTileSet",
         "parameters": [
           {
             "$ref": "#/components/parameters/tileMatrixSetId"
@@ -190,7 +190,7 @@
           "Vector Tiles"
         ],
         "summary": "Retrieve a vector tile from a collection",
-        "operationId": "getTile.dataset.vector.getTile",
+        "operationId": "tiles.dataset.vector.getTile",
         "parameters": [
           {
             "$ref": "#/components/parameters/tileMatrix"

--- a/internal/engine/testdata/expected_sitemap.xml
+++ b/internal/engine/testdata/expected_sitemap.xml
@@ -36,6 +36,9 @@
         <loc>http://localhost:8080/tiles/EuropeanETRS89_LAEAQuad?f=html</loc>
     </url>
     <url>
+        <loc>http://localhost:8080/tiles/WebMercatorQuad?f=html</loc>
+    </url>
+    <url>
         <loc>http://localhost:8080/tileMatrixSets?f=html</loc>
     </url>
     <url>
@@ -43,6 +46,9 @@
     </url>
     <url>
         <loc>http://localhost:8080/tileMatrixSets/EuropeanETRS89_LAEAQuad?f=html</loc>
+    </url>
+    <url>
+        <loc>http://localhost:8080/tileMatrixSets/WebMercatorQuad?f=html</loc>
     </url>
     <url>
         <loc>http://localhost:8080/styles?f=html</loc>

--- a/internal/ogc/tiles/main.go
+++ b/internal/ogc/tiles/main.go
@@ -78,9 +78,8 @@ func NewTiles(e *engine.Engine) *Tiles {
 	tiles := &Tiles{engine: e}
 
 	// TileMatrixSetLimits
-	tiles.tileMatrixSetLimits = make(map[string]map[int]TileMatrixSetLimits)
 	supportedProjections := e.Config.OgcAPI.Tiles.GetProjections()
-	readTileMatrixSetLimits(tiles.tileMatrixSetLimits, supportedProjections)
+	tiles.tileMatrixSetLimits = readTileMatrixSetLimits(supportedProjections)
 
 	// TileMatrixSets
 	renderTileMatrixTemplates(e)
@@ -379,7 +378,8 @@ func getCollectionTitle(collectionID string, metadata *config.GeoSpatialCollecti
 	return collectionID
 }
 
-func readTileMatrixSetLimits(tileMatrixSetLimits map[string]map[int]TileMatrixSetLimits, supportedProjections []config.SupportedSrs) {
+func readTileMatrixSetLimits(supportedProjections []config.SupportedSrs) map[string]map[int]TileMatrixSetLimits {
+	tileMatrixSetLimits := make(map[string]map[int]TileMatrixSetLimits)
 	for _, supportedSrs := range supportedProjections {
 		tileMatrixSetID := config.AllTileProjections[supportedSrs.Srs]
 		yamlFile, err := os.ReadFile(tmsLimitsDir + tileMatrixSetID + ".yaml")
@@ -399,6 +399,7 @@ func readTileMatrixSetLimits(tileMatrixSetLimits map[string]map[int]TileMatrixSe
 		}
 		tileMatrixSetLimits[tileMatrixSetID] = tmsLimits
 	}
+	return tileMatrixSetLimits
 }
 
 func parseTileParams(tileMatrix, tileRow, tileCol string) (int, int, int, error) {

--- a/internal/ogc/tiles/main.go
+++ b/internal/ogc/tiles/main.go
@@ -401,7 +401,7 @@ func readTileMatrixSetLimits(tileMatrixSetLimits map[string]map[int]TileMatrixSe
 	}
 }
 
-func parseTileParams(tileMatrix string, tileRow string, tileCol string) (int, int, int, error) {
+func parseTileParams(tileMatrix, tileRow, tileCol string) (int, int, int, error) {
 	tm, tmErr := strconv.Atoi(tileMatrix)
 	tr, trErr := strconv.Atoi(tileRow)
 	tc, tcErr := strconv.Atoi(tileCol)

--- a/internal/ogc/tiles/main.go
+++ b/internal/ogc/tiles/main.go
@@ -182,7 +182,7 @@ func (t *Tiles) Tile(tilesConfig config.Tiles) http.HandlerFunc {
 		}
 		tm, tr, tc, err := parseTileParams(tileMatrix, tileRow, tileCol)
 		if err != nil {
-			engine.RenderProblemAndLog(engine.ProblemBadRequest, w, err, err.Error())
+			engine.RenderProblemAndLog(engine.ProblemBadRequest, w, err, strings.ReplaceAll(err.Error(), "strconv.Atoi: ", ""))
 			return
 		}
 
@@ -222,7 +222,7 @@ func (t *Tiles) TileForCollection(tilesConfigByCollection map[string]config.Tile
 		}
 		tm, tr, tc, err := parseTileParams(tileMatrix, tileRow, tileCol)
 		if err != nil {
-			engine.RenderProblemAndLog(engine.ProblemBadRequest, w, err, err.Error())
+			engine.RenderProblemAndLog(engine.ProblemBadRequest, w, err, strings.ReplaceAll(err.Error(), "strconv.Atoi: ", ""))
 			return
 		}
 

--- a/internal/ogc/tiles/main.go
+++ b/internal/ogc/tiles/main.go
@@ -3,8 +3,11 @@ package tiles
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
+	"os"
+	"strconv"
 	"strings"
 
 	"github.com/PDOK/gokoala/config"
@@ -12,6 +15,7 @@ import (
 	"github.com/PDOK/gokoala/internal/engine/util"
 	g "github.com/PDOK/gokoala/internal/ogc/common/geospatial"
 	"github.com/go-chi/chi/v5"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -23,6 +27,7 @@ const (
 	defaultTilesTmpl        = "{tms}/{z}/{x}/{y}." + engine.FormatMVTAlternative
 	collectionsCrumb        = "collections/"
 	tilesCrumbTitle         = "Tiles"
+	tmsLimitsDir            = "internal/ogc/tiles/tileMatrixSetLimits/"
 )
 
 var (
@@ -58,11 +63,24 @@ type templateData struct {
 }
 
 type Tiles struct {
-	engine *engine.Engine
+	engine              *engine.Engine
+	tileMatrixSetLimits map[string]map[int]TileMatrixSetLimits
+}
+
+type TileMatrixSetLimits struct {
+	MinCol int `yaml:"minCol" json:"minCol"`
+	MaxCol int `yaml:"maxCol" json:"maxCol"`
+	MinRow int `yaml:"minRow" json:"minRow"`
+	MaxRow int `yaml:"maxRow" json:"maxRow"`
 }
 
 func NewTiles(e *engine.Engine) *Tiles {
 	tiles := &Tiles{engine: e}
+
+	// TileMatrixSetLimits
+	tiles.tileMatrixSetLimits = make(map[string]map[int]TileMatrixSetLimits)
+	supportedProjections := e.Config.OgcAPI.Tiles.GetProjections()
+	readTileMatrixSetLimits(tiles.tileMatrixSetLimits, supportedProjections)
 
 	// TileMatrixSets
 	renderTileMatrixTemplates(e)
@@ -163,6 +181,23 @@ func (t *Tiles) Tile(tilesConfig config.Tiles) http.HandlerFunc {
 			engine.RenderProblemAndLog(engine.ProblemBadRequest, w, err, err.Error())
 			return
 		}
+		tm, tr, tc, err := parseTileParams(tileMatrix, tileRow, tileCol)
+		if err != nil {
+			engine.RenderProblemAndLog(engine.ProblemBadRequest, w, err, err.Error())
+			return
+		}
+
+		if _, ok := t.tileMatrixSetLimits[tileMatrixSetID]; !ok {
+			// unknown tileMatrixSet
+			err = fmt.Errorf("unknown tileMatrixSet '%s'", tileMatrixSetID)
+			engine.RenderProblemAndLog(engine.ProblemBadRequest, w, err, err.Error())
+			return
+		}
+		err = checkTileMatrixSetLimits(t.tileMatrixSetLimits, tileMatrixSetID, tm, tr, tc)
+		if err != nil {
+			engine.RenderProblemAndLog(engine.ProblemNotFound, w, err, err.Error())
+			return
+		}
 
 		target, err := createTilesURL(tileMatrixSetID, tileMatrix, tileCol, tileRow, tilesConfig)
 		if err != nil {
@@ -184,6 +219,23 @@ func (t *Tiles) TileForCollection(tilesConfigByCollection map[string]config.Tile
 		tileCol, err := getTileColumn(r, t.engine.CN.NegotiateFormat(r))
 		if err != nil {
 			engine.RenderProblemAndLog(engine.ProblemBadRequest, w, err, err.Error())
+			return
+		}
+		tm, tr, tc, err := parseTileParams(tileMatrix, tileRow, tileCol)
+		if err != nil {
+			engine.RenderProblemAndLog(engine.ProblemBadRequest, w, err, err.Error())
+			return
+		}
+
+		if _, ok := t.tileMatrixSetLimits[tileMatrixSetID]; !ok {
+			// unknown tileMatrixSet
+			err = fmt.Errorf("unknown tileMatrixSet '%s'", tileMatrixSetID)
+			engine.RenderProblemAndLog(engine.ProblemBadRequest, w, err, err.Error())
+			return
+		}
+		err = checkTileMatrixSetLimits(t.tileMatrixSetLimits, tileMatrixSetID, tm, tr, tc)
+		if err != nil {
+			engine.RenderProblemAndLog(engine.ProblemNotFound, w, err, err.Error())
 			return
 		}
 
@@ -325,4 +377,44 @@ func getCollectionTitle(collectionID string, metadata *config.GeoSpatialCollecti
 		return *metadata.Title
 	}
 	return collectionID
+}
+
+func readTileMatrixSetLimits(tileMatrixSetLimits map[string]map[int]TileMatrixSetLimits, supportedProjections []config.SupportedSrs) {
+	for _, supportedSrs := range supportedProjections {
+		tileMatrixSetID := config.AllTileProjections[supportedSrs.Srs]
+		yamlFile, err := os.ReadFile(tmsLimitsDir + tileMatrixSetID + ".yaml")
+		if err != nil {
+			log.Fatalf("unable to read file %s", tileMatrixSetID+".yaml")
+		}
+		tmsLimits := make(map[int]TileMatrixSetLimits)
+		err = yaml.Unmarshal(yamlFile, &tmsLimits)
+		if err != nil {
+			log.Fatalf("cannot unmarshal yaml: %v", err)
+		}
+		// keep only the zoomlevels supported
+		for tm := range tmsLimits {
+			if tm < supportedSrs.ZoomLevelRange.Start || tm > supportedSrs.ZoomLevelRange.End {
+				delete(tmsLimits, tm)
+			}
+		}
+		tileMatrixSetLimits[tileMatrixSetID] = tmsLimits
+	}
+}
+
+func parseTileParams(tileMatrix string, tileRow string, tileCol string) (int, int, int, error) {
+	tm, tmErr := strconv.Atoi(tileMatrix)
+	tr, trErr := strconv.Atoi(tileRow)
+	tc, tcErr := strconv.Atoi(tileCol)
+	return tm, tr, tc, errors.Join(tmErr, trErr, tcErr)
+}
+
+func checkTileMatrixSetLimits(tileMatrixSetLimits map[string]map[int]TileMatrixSetLimits, tileMatrixSetID string, tileMatrix, tileRow, tileCol int) error {
+	if limits, ok := tileMatrixSetLimits[tileMatrixSetID][tileMatrix]; !ok {
+		// tileMatrix out of supported range
+		return fmt.Errorf("tileMatrix %d is out of range", tileMatrix)
+	} else if tileRow < limits.MinRow || tileRow > limits.MaxRow || tileCol < limits.MinCol || tileCol > limits.MaxCol {
+		// tileRow and/or tileCol out of supported range
+		return fmt.Errorf("tileRow/tileCol %d/%d is out of range", tileRow, tileCol)
+	}
+	return nil
 }

--- a/internal/ogc/tiles/main.go
+++ b/internal/ogc/tiles/main.go
@@ -300,6 +300,13 @@ func renderTilesTemplates(e *engine.Engine, collection *config.GeoSpatialCollect
 				},
 			}...)
 			path = g.CollectionsPath + "/" + collectionID + tilesPath + "/" + projection
+		} else {
+			projectionBreadcrumbs = append(projectionBreadcrumbs, []engine.Breadcrumb{
+				{
+					Name: projection,
+					Path: path,
+				},
+			}...)
 		}
 		e.RenderTemplatesWithParams(path,
 			data,

--- a/internal/ogc/tiles/main_test.go
+++ b/internal/ogc/tiles/main_test.go
@@ -233,13 +233,13 @@ func TestTiles_Tile(t *testing.T) {
 			fields: fields{
 				configFile:      "internal/ogc/tiles/testdata/config_tiles_urltemplate.yaml",
 				url:             "http://localhost:8080/tiles/:tileMatrixSetId/:tileMatrix/:tileRow/:tileCol?f=mvt",
-				tileMatrixSetID: "NetherlandsRDNewQuad",
+				tileMatrixSetID: "EuropeanETRS89_LAEAQuad",
 				tileMatrix:      "5",
 				tileRow:         "10",
 				tileCol:         "15",
 			},
 			want: want{
-				body:       "/foo/NetherlandsRDNewQuad/5/10/15",
+				body:       "/foo/EuropeanETRS89_LAEAQuad/5/10/15",
 				statusCode: http.StatusOK,
 			},
 		},

--- a/internal/ogc/tiles/main_test.go
+++ b/internal/ogc/tiles/main_test.go
@@ -243,6 +243,66 @@ func TestTiles_Tile(t *testing.T) {
 				statusCode: http.StatusOK,
 			},
 		},
+		{
+			name: "request unknown tileMatrixSet",
+			fields: fields{
+				configFile:      "internal/ogc/tiles/testdata/config_tiles_toplevel.yaml",
+				url:             "http://localhost:8080/tiles/:tileMatrixSetId/:tileMatrix/:tileRow/:tileCol?f=mvt",
+				tileMatrixSetID: "EuropeanETRS89_LAEAQuad",
+				tileMatrix:      "5",
+				tileRow:         "10",
+				tileCol:         "15",
+			},
+			want: want{
+				body:       "unknown tileMatrixSet 'EuropeanETRS89_LAEAQuad'",
+				statusCode: http.StatusBadRequest,
+			},
+		},
+		{
+			name: "request tile in unsupported tileMatrix",
+			fields: fields{
+				configFile:      "internal/ogc/tiles/testdata/config_tiles_toplevel.yaml",
+				url:             "http://localhost:8080/tiles/:tileMatrixSetId/:tileMatrix/:tileRow/:tileCol",
+				tileMatrixSetID: "NetherlandsRDNewQuad",
+				tileMatrix:      "13",
+				tileRow:         "10",
+				tileCol:         "15.pbf",
+			},
+			want: want{
+				body:       "tileMatrix 13 is out of range",
+				statusCode: http.StatusNotFound,
+			},
+		},
+		{
+			name: "request tile beyond tileMatrixSetLimits",
+			fields: fields{
+				configFile:      "internal/ogc/tiles/testdata/config_tiles_toplevel.yaml",
+				url:             "http://localhost:8080/tiles/:tileMatrixSetId/:tileMatrix/:tileRow/:tileCol",
+				tileMatrixSetID: "NetherlandsRDNewQuad",
+				tileMatrix:      "5",
+				tileRow:         "32",
+				tileCol:         "32.pbf",
+			},
+			want: want{
+				body:       "tileRow/tileCol 32/32 is out of range",
+				statusCode: http.StatusNotFound,
+			},
+		},
+		{
+			name: "invalid request parameter",
+			fields: fields{
+				configFile:      "internal/ogc/tiles/testdata/config_tiles_toplevel.yaml",
+				url:             "http://localhost:8080/tiles/:tileMatrixSetId/:tileMatrix/:tileRow/:tileCol",
+				tileMatrixSetID: "NetherlandsRDNewQuad",
+				tileMatrix:      "5",
+				tileRow:         "3A",
+				tileCol:         "E2.pbf",
+			},
+			want: want{
+				body:       "invalid syntax",
+				statusCode: http.StatusBadRequest,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/ogc/tiles/templates/tiles.go.json
+++ b/internal/ogc/tiles/templates/tiles.go.json
@@ -46,6 +46,7 @@
           "crs": "https://www.opengis.net/def/crs/EPSG/0/28992",
           "tileMatrixSetId": "NetherlandsRDNewQuad",
           "tileMatrixSetDefinition": "{{ $.Config.BaseURL }}/tileMatrixSets/NetherlandsRDNewQuad",
+          "tileMatrixSetURI": "{{ $.Config.BaseURL }}/tileMatrixSets/NetherlandsRDNewQuad",
           "tileMatrixSetLimits": [
             {{ $first := true }}
             {{ if eq $type.ZoomLevelRange.Start 0 }}

--- a/internal/ogc/tiles/templates/tiles.go.json
+++ b/internal/ogc/tiles/templates/tiles.go.json
@@ -33,12 +33,192 @@
               "type": "application/json",
               "title": "Definition of NetherlandsRDNewQuad TileMatrixSet",
               "href": "{{ $.Config.BaseURL }}/tileMatrixSets/NetherlandsRDNewQuad"
+            },
+            {
+              "rel": "item",
+              "type" : "application/vnd.mapbox-vector-tile",
+              "title" : "Mapbox vector tiles; the link is a URI template where {tileMatrix}/{tileRow}/{tileCol} is the tile in the tiling scheme 'NetherlandsRDNewQuad'",
+              "href" : "{{ $.Config.BaseURL }}/tiles/NetherlandsRDNewQuad/{tileMatrix}/{tileRow}/{tileCol}?f=mvt",
+              "templated" : true
             }
           ],
           "dataType": "vector",
           "crs": "https://www.opengis.net/def/crs/EPSG/0/28992",
           "tileMatrixSetId": "NetherlandsRDNewQuad",
-          "tileMatrixSetDefinition": "{{ $.Config.BaseURL }}/tileMatrixSets/NetherlandsRDNewQuad"
+          "tileMatrixSetDefinition": "{{ $.Config.BaseURL }}/tileMatrixSets/NetherlandsRDNewQuad",
+          "tileMatrixSetLimits": [
+            {{ $first := true }}
+            {{ if eq $type.ZoomLevelRange.Start 0 }}
+            {{ if not $first }}{{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "0",
+              "minTileRow": 0,
+              "maxTileRow": 0,
+              "minTileCol": 0,
+              "maxTileCol": 0
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 1) (ge $type.ZoomLevelRange.End 1) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "1",
+              "minTileRow": 0,
+              "maxTileRow": 1,
+              "minTileCol": 0,
+              "maxTileCol": 1
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 2) (ge $type.ZoomLevelRange.End 2) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "2",
+              "minTileRow": 0,
+              "maxTileRow": 3,
+              "minTileCol": 0,
+              "maxTileCol": 3
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 3) (ge $type.ZoomLevelRange.End 3) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "3",
+              "minTileRow": 0,
+              "maxTileRow": 7,
+              "minTileCol": 0,
+              "maxTileCol": 7
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 4) (ge $type.ZoomLevelRange.End 4) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "4",
+              "minTileRow": 0,
+              "maxTileRow": 15,
+              "minTileCol": 0,
+              "maxTileCol": 15
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 5) (ge $type.ZoomLevelRange.End 5) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "5",
+              "minTileRow": 0,
+              "maxTileRow": 31,
+              "minTileCol": 0,
+              "maxTileCol": 31
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 6) (ge $type.ZoomLevelRange.End 6) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "6",
+              "minTileRow": 0,
+              "maxTileRow": 63,
+              "minTileCol": 0,
+              "maxTileCol": 63
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 7) (ge $type.ZoomLevelRange.End 7) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "7",
+              "minTileRow": 0,
+              "maxTileRow": 127,
+              "minTileCol": 0,
+              "maxTileCol": 127
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 8) (ge $type.ZoomLevelRange.End 8) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "8",
+              "minTileRow": 0,
+              "maxTileRow": 255,
+              "minTileCol": 0,
+              "maxTileCol": 255
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 9) (ge $type.ZoomLevelRange.End 9) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "9",
+              "minTileRow": 0,
+              "maxTileRow": 511,
+              "minTileCol": 0,
+              "maxTileCol": 511
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 10) (ge $type.ZoomLevelRange.End 10) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "10",
+              "minTileRow": 0,
+              "maxTileRow": 1023,
+              "minTileCol": 0,
+              "maxTileCol": 1023
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 11) (ge $type.ZoomLevelRange.End 11) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "11",
+              "minTileRow": 0,
+              "maxTileRow": 2047,
+              "minTileCol": 0,
+              "maxTileCol": 2047
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 12) (ge $type.ZoomLevelRange.End 12) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "12",
+              "minTileRow": 0,
+              "maxTileRow": 4095,
+              "minTileCol": 0,
+              "maxTileCol": 4095
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 13) (ge $type.ZoomLevelRange.End 13) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "13",
+              "minTileRow": 0,
+              "maxTileRow": 8191,
+              "minTileCol": 0,
+              "maxTileCol": 8191
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 14) (ge $type.ZoomLevelRange.End 14) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "14",
+              "minTileRow": 0,
+              "maxTileRow": 16383,
+              "minTileCol": 0,
+              "maxTileCol": 16383
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 15) (ge $type.ZoomLevelRange.End 15) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "15",
+              "minTileRow": 0,
+              "maxTileRow": 32767,
+              "minTileCol": 0,
+              "maxTileCol": 32767
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 16) (ge $type.ZoomLevelRange.End 16) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "16",
+              "minTileRow": 0,
+              "maxTileRow": 65535,
+              "minTileCol": 0,
+              "maxTileCol": 65535
+            }
+            {{end}}
+          ]
         }
       {{end}}
       {{ if (eq $type.Srs "EPSG:3035") }}
@@ -55,12 +235,182 @@
               "type": "application/json",
               "title": "Definition of EuropeanETRS89_LAEAQuad TileMatrixSet",
               "href": "{{ $.Config.BaseURL }}/tileMatrixSets/EuropeanETRS89_LAEAQuad"
+            },
+            {
+              "rel": "item",
+              "type" : "application/vnd.mapbox-vector-tile",
+              "title" : "Mapbox vector tiles; the link is a URI template where {tileMatrix}/{tileRow}/{tileCol} is the tile in the tiling scheme 'EuropeanETRS89_LAEAQuad'",
+              "href" : "{{ $.Config.BaseURL }}/tiles/EuropeanETRS89_LAEAQuad/{tileMatrix}/{tileRow}/{tileCol}?f=mvt",
+              "templated" : true
             }
           ],
           "dataType": "vector",
           "crs": "https://www.opengis.net/def/crs/EPSG/0/3035",
           "tileMatrixSetId": "EuropeanETRS89_LAEAQuad",
-          "tileMatrixSetDefinition": "{{ $.Config.BaseURL }}/tileMatrixSets/EuropeanETRS89_LAEAQuad"
+          "tileMatrixSetDefinition": "{{ $.Config.BaseURL }}/tileMatrixSets/EuropeanETRS89_LAEAQuad",
+          "tileMatrixSetLimits": [
+            {{ $first := true }}
+            {{ if eq $type.ZoomLevelRange.Start 0 }}
+            {{ if not $first }}{{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "0",
+              "minTileRow": 0,
+              "maxTileRow": 0,
+              "minTileCol": 0,
+              "maxTileCol": 0
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 1) (ge $type.ZoomLevelRange.End 1) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "1",
+              "minTileRow": 0,
+              "maxTileRow": 1,
+              "minTileCol": 0,
+              "maxTileCol": 1
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 2) (ge $type.ZoomLevelRange.End 2) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "2",
+              "minTileRow": 0,
+              "maxTileRow": 3,
+              "minTileCol": 0,
+              "maxTileCol": 3
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 3) (ge $type.ZoomLevelRange.End 3) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "3",
+              "minTileRow": 0,
+              "maxTileRow": 7,
+              "minTileCol": 0,
+              "maxTileCol": 7
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 4) (ge $type.ZoomLevelRange.End 4) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "4",
+              "minTileRow": 0,
+              "maxTileRow": 15,
+              "minTileCol": 0,
+              "maxTileCol": 15
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 5) (ge $type.ZoomLevelRange.End 5) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "5",
+              "minTileRow": 0,
+              "maxTileRow": 31,
+              "minTileCol": 0,
+              "maxTileCol": 31
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 6) (ge $type.ZoomLevelRange.End 6) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "6",
+              "minTileRow": 0,
+              "maxTileRow": 63,
+              "minTileCol": 0,
+              "maxTileCol": 63
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 7) (ge $type.ZoomLevelRange.End 7) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "7",
+              "minTileRow": 0,
+              "maxTileRow": 127,
+              "minTileCol": 0,
+              "maxTileCol": 127
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 8) (ge $type.ZoomLevelRange.End 8) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "8",
+              "minTileRow": 0,
+              "maxTileRow": 255,
+              "minTileCol": 0,
+              "maxTileCol": 255
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 9) (ge $type.ZoomLevelRange.End 9) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "9",
+              "minTileRow": 0,
+              "maxTileRow": 511,
+              "minTileCol": 0,
+              "maxTileCol": 511
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 10) (ge $type.ZoomLevelRange.End 10) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "10",
+              "minTileRow": 0,
+              "maxTileRow": 1023,
+              "minTileCol": 0,
+              "maxTileCol": 1023
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 11) (ge $type.ZoomLevelRange.End 11) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "11",
+              "minTileRow": 0,
+              "maxTileRow": 2047,
+              "minTileCol": 0,
+              "maxTileCol": 2047
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 12) (ge $type.ZoomLevelRange.End 12) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "12",
+              "minTileRow": 0,
+              "maxTileRow": 4095,
+              "minTileCol": 0,
+              "maxTileCol": 4095
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 13) (ge $type.ZoomLevelRange.End 13) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "13",
+              "minTileRow": 0,
+              "maxTileRow": 8191,
+              "minTileCol": 0,
+              "maxTileCol": 8191
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 14) (ge $type.ZoomLevelRange.End 14) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "14",
+              "minTileRow": 0,
+              "maxTileRow": 16383,
+              "minTileCol": 0,
+              "maxTileCol": 16383
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 15) (ge $type.ZoomLevelRange.End 15) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "15",
+              "minTileRow": 0,
+              "maxTileRow": 32767,
+              "minTileCol": 0,
+              "maxTileCol": 32767
+            }
+            {{end}}
+          ]
         }
       {{end}}
       {{ if (eq $type.Srs "EPSG:3857") }}
@@ -77,12 +427,202 @@
               "type": "application/json",
               "title": "Definition of WebMercatorQuad TileMatrixSet",
               "href": "{{ $.Config.BaseURL }}/tileMatrixSets/WebMercatorQuad"
+            },
+            {
+              "rel": "item",
+              "type" : "application/vnd.mapbox-vector-tile",
+              "title" : "Mapbox vector tiles; the link is a URI template where {tileMatrix}/{tileRow}/{tileCol} is the tile in the tiling scheme 'WebMercatorQuad'",
+              "href" : "{{ $.Config.BaseURL }}/tiles/WebMercatorQuad/{tileMatrix}/{tileRow}/{tileCol}?f=mvt",
+              "templated" : true
             }
           ],
           "dataType": "vector",
           "crs": "https://www.opengis.net/def/crs/EPSG/0/3857",
           "tileMatrixSetId": "WebMercatorQuad",
-          "tileMatrixSetDefinition": "{{ $.Config.BaseURL }}/tileMatrixSets/WebMercatorQuad"
+          "tileMatrixSetDefinition": "{{ $.Config.BaseURL }}/tileMatrixSets/WebMercatorQuad",
+          "tileMatrixSetLimits": [
+            {{ $first := true }}
+            {{ if eq $type.ZoomLevelRange.Start 0 }}
+            {{ if not $first }}{{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "0",
+              "minTileRow": 0,
+              "maxTileRow": 0,
+              "minTileCol": 0,
+              "maxTileCol": 0
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 1) (ge $type.ZoomLevelRange.End 1) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "1",
+              "minTileRow": 0,
+              "maxTileRow": 1,
+              "minTileCol": 0,
+              "maxTileCol": 1
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 2) (ge $type.ZoomLevelRange.End 2) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "2",
+              "minTileRow": 0,
+              "maxTileRow": 3,
+              "minTileCol": 0,
+              "maxTileCol": 3
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 3) (ge $type.ZoomLevelRange.End 3) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "3",
+              "minTileRow": 0,
+              "maxTileRow": 7,
+              "minTileCol": 0,
+              "maxTileCol": 7
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 4) (ge $type.ZoomLevelRange.End 4) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "4",
+              "minTileRow": 0,
+              "maxTileRow": 15,
+              "minTileCol": 0,
+              "maxTileCol": 15
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 5) (ge $type.ZoomLevelRange.End 5) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "5",
+              "minTileRow": 0,
+              "maxTileRow": 31,
+              "minTileCol": 0,
+              "maxTileCol": 31
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 6) (ge $type.ZoomLevelRange.End 6) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "6",
+              "minTileRow": 0,
+              "maxTileRow": 63,
+              "minTileCol": 0,
+              "maxTileCol": 63
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 7) (ge $type.ZoomLevelRange.End 7) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "7",
+              "minTileRow": 0,
+              "maxTileRow": 127,
+              "minTileCol": 0,
+              "maxTileCol": 127
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 8) (ge $type.ZoomLevelRange.End 8) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "8",
+              "minTileRow": 0,
+              "maxTileRow": 255,
+              "minTileCol": 0,
+              "maxTileCol": 255
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 9) (ge $type.ZoomLevelRange.End 9) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "9",
+              "minTileRow": 0,
+              "maxTileRow": 511,
+              "minTileCol": 0,
+              "maxTileCol": 511
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 10) (ge $type.ZoomLevelRange.End 10) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "10",
+              "minTileRow": 0,
+              "maxTileRow": 1023,
+              "minTileCol": 0,
+              "maxTileCol": 1023
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 11) (ge $type.ZoomLevelRange.End 11) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "11",
+              "minTileRow": 0,
+              "maxTileRow": 2047,
+              "minTileCol": 0,
+              "maxTileCol": 2047
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 12) (ge $type.ZoomLevelRange.End 12) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "12",
+              "minTileRow": 0,
+              "maxTileRow": 4095,
+              "minTileCol": 0,
+              "maxTileCol": 4095
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 13) (ge $type.ZoomLevelRange.End 13) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "13",
+              "minTileRow": 0,
+              "maxTileRow": 8191,
+              "minTileCol": 0,
+              "maxTileCol": 8191
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 14) (ge $type.ZoomLevelRange.End 14) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "14",
+              "minTileRow": 0,
+              "maxTileRow": 16383,
+              "minTileCol": 0,
+              "maxTileCol": 16383
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 15) (ge $type.ZoomLevelRange.End 15) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "15",
+              "minTileRow": 0,
+              "maxTileRow": 32767,
+              "minTileCol": 0,
+              "maxTileCol": 32767
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 16) (ge $type.ZoomLevelRange.End 16) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "16",
+              "minTileRow": 0,
+              "maxTileRow": 65535,
+              "minTileCol": 0,
+              "maxTileCol": 65535
+            }
+            {{end}}
+            {{ if and (le $type.ZoomLevelRange.Start 17) (ge $type.ZoomLevelRange.End 17) }}
+            {{ if not $first }}, {{else}} {{$first = false}} {{end}}
+            {
+              "tileMatrix": "17",
+              "minTileRow": 0,
+              "maxTileRow": 131071,
+              "minTileCol": 0,
+              "maxTileCol": 131071
+            }
+            {{end}}
+          ]
         }
       {{end}}
     {{end}}

--- a/internal/ogc/tiles/templates/tiles.go.json
+++ b/internal/ogc/tiles/templates/tiles.go.json
@@ -248,6 +248,7 @@
           "crs": "https://www.opengis.net/def/crs/EPSG/0/3035",
           "tileMatrixSetId": "EuropeanETRS89_LAEAQuad",
           "tileMatrixSetDefinition": "{{ $.Config.BaseURL }}/tileMatrixSets/EuropeanETRS89_LAEAQuad",
+          "tileMatrixSetURI": "http://www.opengis.net/def/tilematrixset/OGC/1.0/EuropeanETRS89_LAEAQuad",
           "tileMatrixSetLimits": [
             {{ $first := true }}
             {{ if eq $type.ZoomLevelRange.Start 0 }}
@@ -440,6 +441,7 @@
           "crs": "https://www.opengis.net/def/crs/EPSG/0/3857",
           "tileMatrixSetId": "WebMercatorQuad",
           "tileMatrixSetDefinition": "{{ $.Config.BaseURL }}/tileMatrixSets/WebMercatorQuad",
+          "tileMatrixSetURI": "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad",
           "tileMatrixSetLimits": [
             {{ $first := true }}
             {{ if eq $type.ZoomLevelRange.Start 0 }}

--- a/internal/ogc/tiles/testdata/expected_collection_level_tiles.json
+++ b/internal/ogc/tiles/testdata/expected_collection_level_tiles.json
@@ -28,12 +28,112 @@
           "type": "application/json",
           "title": "Definition of NetherlandsRDNewQuad TileMatrixSet",
           "href": "http://localhost:8080/tileMatrixSets/NetherlandsRDNewQuad"
+        },
+        {
+          "rel": "item",
+          "type" : "application/vnd.mapbox-vector-tile",
+          "title" : "Mapbox vector tiles; the link is a URI template where {tileMatrix}/{tileRow}/{tileCol} is the tile in the tiling scheme 'NetherlandsRDNewQuad'",
+          "href" : "http://localhost:8080/tiles/NetherlandsRDNewQuad/{tileMatrix}/{tileRow}/{tileCol}?f=mvt",
+          "templated" : true
         }
       ],
       "dataType": "vector",
       "crs": "https://www.opengis.net/def/crs/EPSG/0/28992",
       "tileMatrixSetId": "NetherlandsRDNewQuad",
-      "tileMatrixSetDefinition": "http://localhost:8080/tileMatrixSets/NetherlandsRDNewQuad"
+      "tileMatrixSetDefinition": "http://localhost:8080/tileMatrixSets/NetherlandsRDNewQuad",
+      "tileMatrixSetLimits": [
+        {
+          "tileMatrix": "0",
+          "minTileRow": 0,
+          "maxTileRow": 0,
+          "minTileCol": 0,
+          "maxTileCol": 0
+        },
+        {
+          "tileMatrix": "1",
+          "minTileRow": 0,
+          "maxTileRow": 1,
+          "minTileCol": 0,
+          "maxTileCol": 1
+        },
+        {
+          "tileMatrix": "2",
+          "minTileRow": 0,
+          "maxTileRow": 3,
+          "minTileCol": 0,
+          "maxTileCol": 3
+        },
+        {
+          "tileMatrix": "3",
+          "minTileRow": 0,
+          "maxTileRow": 7,
+          "minTileCol": 0,
+          "maxTileCol": 7
+        },
+        {
+          "tileMatrix": "4",
+          "minTileRow": 0,
+          "maxTileRow": 15,
+          "minTileCol": 0,
+          "maxTileCol": 15
+        },
+        {
+          "tileMatrix": "5",
+          "minTileRow": 0,
+          "maxTileRow": 31,
+          "minTileCol": 0,
+          "maxTileCol": 31
+        },
+        {
+          "tileMatrix": "6",
+          "minTileRow": 0,
+          "maxTileRow": 63,
+          "minTileCol": 0,
+          "maxTileCol": 63
+        },
+        {
+          "tileMatrix": "7",
+          "minTileRow": 0,
+          "maxTileRow": 127,
+          "minTileCol": 0,
+          "maxTileCol": 127
+        },
+        {
+          "tileMatrix": "8",
+          "minTileRow": 0,
+          "maxTileRow": 255,
+          "minTileCol": 0,
+          "maxTileCol": 255
+        },
+        {
+          "tileMatrix": "9",
+          "minTileRow": 0,
+          "maxTileRow": 511,
+          "minTileCol": 0,
+          "maxTileCol": 511
+        },
+        {
+          "tileMatrix": "10",
+          "minTileRow": 0,
+          "maxTileRow": 1023,
+          "minTileCol": 0,
+          "maxTileCol": 1023
+        },
+        {
+          "tileMatrix": "11",
+          "minTileRow": 0,
+          "maxTileRow": 2047,
+          "minTileCol": 0,
+          "maxTileCol": 2047
+        },
+        {
+          "tileMatrix": "12",
+          "minTileRow": 0,
+          "maxTileRow": 4095,
+          "minTileCol": 0,
+          "maxTileCol": 4095
+        }
+      ]
     }
   ]
 }

--- a/internal/ogc/tiles/testdata/expected_collection_level_tiles.json
+++ b/internal/ogc/tiles/testdata/expected_collection_level_tiles.json
@@ -41,6 +41,7 @@
       "crs": "https://www.opengis.net/def/crs/EPSG/0/28992",
       "tileMatrixSetId": "NetherlandsRDNewQuad",
       "tileMatrixSetDefinition": "http://localhost:8080/tileMatrixSets/NetherlandsRDNewQuad",
+      "tileMatrixSetURI": "http://localhost:8080/tileMatrixSets/NetherlandsRDNewQuad",
       "tileMatrixSetLimits": [
         {
           "tileMatrix": "0",

--- a/internal/ogc/tiles/testdata/expected_top_level_tiles.json
+++ b/internal/ogc/tiles/testdata/expected_top_level_tiles.json
@@ -28,12 +28,112 @@
           "type": "application/json",
           "title": "Definition of NetherlandsRDNewQuad TileMatrixSet",
           "href": "http://localhost:8080/tileMatrixSets/NetherlandsRDNewQuad"
+        },
+        {
+          "rel": "item",
+          "type" : "application/vnd.mapbox-vector-tile",
+          "title" : "Mapbox vector tiles; the link is a URI template where {tileMatrix}/{tileRow}/{tileCol} is the tile in the tiling scheme 'NetherlandsRDNewQuad'",
+          "href" : "http://localhost:8080/tiles/NetherlandsRDNewQuad/{tileMatrix}/{tileRow}/{tileCol}?f=mvt",
+          "templated" : true
         }
       ],
       "dataType": "vector",
       "crs": "https://www.opengis.net/def/crs/EPSG/0/28992",
       "tileMatrixSetId": "NetherlandsRDNewQuad",
-      "tileMatrixSetDefinition": "http://localhost:8080/tileMatrixSets/NetherlandsRDNewQuad"
+      "tileMatrixSetDefinition": "http://localhost:8080/tileMatrixSets/NetherlandsRDNewQuad",
+      "tileMatrixSetLimits": [
+        {
+          "tileMatrix": "0",
+          "minTileRow": 0,
+          "maxTileRow": 0,
+          "minTileCol": 0,
+          "maxTileCol": 0
+        },
+        {
+          "tileMatrix": "1",
+          "minTileRow": 0,
+          "maxTileRow": 1,
+          "minTileCol": 0,
+          "maxTileCol": 1
+        },
+        {
+          "tileMatrix": "2",
+          "minTileRow": 0,
+          "maxTileRow": 3,
+          "minTileCol": 0,
+          "maxTileCol": 3
+        },
+        {
+          "tileMatrix": "3",
+          "minTileRow": 0,
+          "maxTileRow": 7,
+          "minTileCol": 0,
+          "maxTileCol": 7
+        },
+        {
+          "tileMatrix": "4",
+          "minTileRow": 0,
+          "maxTileRow": 15,
+          "minTileCol": 0,
+          "maxTileCol": 15
+        },
+        {
+          "tileMatrix": "5",
+          "minTileRow": 0,
+          "maxTileRow": 31,
+          "minTileCol": 0,
+          "maxTileCol": 31
+        },
+        {
+          "tileMatrix": "6",
+          "minTileRow": 0,
+          "maxTileRow": 63,
+          "minTileCol": 0,
+          "maxTileCol": 63
+        },
+        {
+          "tileMatrix": "7",
+          "minTileRow": 0,
+          "maxTileRow": 127,
+          "minTileCol": 0,
+          "maxTileCol": 127
+        },
+        {
+          "tileMatrix": "8",
+          "minTileRow": 0,
+          "maxTileRow": 255,
+          "minTileCol": 0,
+          "maxTileCol": 255
+        },
+        {
+          "tileMatrix": "9",
+          "minTileRow": 0,
+          "maxTileRow": 511,
+          "minTileCol": 0,
+          "maxTileCol": 511
+        },
+        {
+          "tileMatrix": "10",
+          "minTileRow": 0,
+          "maxTileRow": 1023,
+          "minTileCol": 0,
+          "maxTileCol": 1023
+        },
+        {
+          "tileMatrix": "11",
+          "minTileRow": 0,
+          "maxTileRow": 2047,
+          "minTileCol": 0,
+          "maxTileCol": 2047
+        },
+        {
+          "tileMatrix": "12",
+          "minTileRow": 0,
+          "maxTileRow": 4095,
+          "minTileCol": 0,
+          "maxTileCol": 4095
+        }
+      ]
     },
     {
       "links": [
@@ -47,12 +147,148 @@
           "type": "application/json",
           "title": "Definition of WebMercatorQuad TileMatrixSet",
           "href": "http://localhost:8080/tileMatrixSets/WebMercatorQuad"
+        },
+        {
+          "rel": "item",
+          "type" : "application/vnd.mapbox-vector-tile",
+          "title" : "Mapbox vector tiles; the link is a URI template where {tileMatrix}/{tileRow}/{tileCol} is the tile in the tiling scheme 'WebMercatorQuad'",
+          "href" : "http://localhost:8080/tiles/WebMercatorQuad/{tileMatrix}/{tileRow}/{tileCol}?f=mvt",
+          "templated" : true
         }
       ],
       "dataType": "vector",
       "crs": "https://www.opengis.net/def/crs/EPSG/0/3857",
       "tileMatrixSetId": "WebMercatorQuad",
-      "tileMatrixSetDefinition": "http://localhost:8080/tileMatrixSets/WebMercatorQuad"
+      "tileMatrixSetDefinition": "http://localhost:8080/tileMatrixSets/WebMercatorQuad",
+      "tileMatrixSetURI": "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad",
+      "tileMatrixSetLimits": [
+        {
+          "tileMatrix": "0",
+          "minTileRow": 0,
+          "maxTileRow": 0,
+          "minTileCol": 0,
+          "maxTileCol": 0
+        },
+        {
+          "tileMatrix": "1",
+          "minTileRow": 0,
+          "maxTileRow": 1,
+          "minTileCol": 0,
+          "maxTileCol": 1
+        },
+        {
+          "tileMatrix": "2",
+          "minTileRow": 0,
+          "maxTileRow": 3,
+          "minTileCol": 0,
+          "maxTileCol": 3
+        },
+        {
+          "tileMatrix": "3",
+          "minTileRow": 0,
+          "maxTileRow": 7,
+          "minTileCol": 0,
+          "maxTileCol": 7
+        },
+        {
+          "tileMatrix": "4",
+          "minTileRow": 0,
+          "maxTileRow": 15,
+          "minTileCol": 0,
+          "maxTileCol": 15
+        },
+        {
+          "tileMatrix": "5",
+          "minTileRow": 0,
+          "maxTileRow": 31,
+          "minTileCol": 0,
+          "maxTileCol": 31
+        },
+        {
+          "tileMatrix": "6",
+          "minTileRow": 0,
+          "maxTileRow": 63,
+          "minTileCol": 0,
+          "maxTileCol": 63
+        },
+        {
+          "tileMatrix": "7",
+          "minTileRow": 0,
+          "maxTileRow": 127,
+          "minTileCol": 0,
+          "maxTileCol": 127
+        },
+        {
+          "tileMatrix": "8",
+          "minTileRow": 0,
+          "maxTileRow": 255,
+          "minTileCol": 0,
+          "maxTileCol": 255
+        },
+        {
+          "tileMatrix": "9",
+          "minTileRow": 0,
+          "maxTileRow": 511,
+          "minTileCol": 0,
+          "maxTileCol": 511
+        },
+        {
+          "tileMatrix": "10",
+          "minTileRow": 0,
+          "maxTileRow": 1023,
+          "minTileCol": 0,
+          "maxTileCol": 1023
+        },
+        {
+          "tileMatrix": "11",
+          "minTileRow": 0,
+          "maxTileRow": 2047,
+          "minTileCol": 0,
+          "maxTileCol": 2047
+        },
+        {
+          "tileMatrix": "12",
+          "minTileRow": 0,
+          "maxTileRow": 4095,
+          "minTileCol": 0,
+          "maxTileCol": 4095
+        },
+        {
+          "tileMatrix": "13",
+          "minTileRow": 0,
+          "maxTileRow": 8191,
+          "minTileCol": 0,
+          "maxTileCol": 8191
+        },
+        {
+          "tileMatrix": "14",
+          "minTileRow": 0,
+          "maxTileRow": 16383,
+          "minTileCol": 0,
+          "maxTileCol": 16383
+        },
+        {
+          "tileMatrix": "15",
+          "minTileRow": 0,
+          "maxTileRow": 32767,
+          "minTileCol": 0,
+          "maxTileCol": 32767
+        },
+        {
+          "tileMatrix": "16",
+          "minTileRow": 0,
+          "maxTileRow": 65535,
+          "minTileCol": 0,
+          "maxTileCol": 65535
+        },
+        {
+          "tileMatrix": "17",
+          "minTileRow": 0,
+          "maxTileRow": 131071,
+          "minTileCol": 0,
+          "maxTileCol": 131071
+        }
+      ]
     }
   ]
 }

--- a/internal/ogc/tiles/testdata/expected_top_level_tiles.json
+++ b/internal/ogc/tiles/testdata/expected_top_level_tiles.json
@@ -41,6 +41,7 @@
       "crs": "https://www.opengis.net/def/crs/EPSG/0/28992",
       "tileMatrixSetId": "NetherlandsRDNewQuad",
       "tileMatrixSetDefinition": "http://localhost:8080/tileMatrixSets/NetherlandsRDNewQuad",
+      "tileMatrixSetURI": "http://localhost:8080/tileMatrixSets/NetherlandsRDNewQuad",
       "tileMatrixSetLimits": [
         {
           "tileMatrix": "0",

--- a/internal/ogc/tiles/tileMatrixSetLimits/EuropeanETRS89_LAEAQuad.yaml
+++ b/internal/ogc/tiles/tileMatrixSetLimits/EuropeanETRS89_LAEAQuad.yaml
@@ -1,0 +1,80 @@
+0:
+  minCol: 0
+  maxCol: 0
+  minRow: 0
+  maxRow: 0
+1:
+  minCol: 0
+  maxCol: 1
+  minRow: 0
+  maxRow: 1
+2:
+  minCol: 0
+  maxCol: 3
+  minRow: 0
+  maxRow: 3
+3:
+  minCol: 0
+  maxCol: 7
+  minRow: 0
+  maxRow: 7
+4:
+  minCol: 0
+  maxCol: 15
+  minRow: 0
+  maxRow: 15
+5:
+  minCol: 0
+  maxCol: 31
+  minRow: 0
+  maxRow: 31
+6:
+  minCol: 0
+  maxCol: 63
+  minRow: 0
+  maxRow: 63
+7:
+  minCol: 0
+  maxCol: 127
+  minRow: 0
+  maxRow: 127
+8:
+  minCol: 0
+  maxCol: 255
+  minRow: 0
+  maxRow: 255
+9:
+  minCol: 0
+  maxCol: 511
+  minRow: 0
+  maxRow: 511
+10:
+  minCol: 0
+  maxCol: 1023
+  minRow: 0
+  maxRow: 1023
+11:
+  minCol: 0
+  maxCol: 2047
+  minRow: 0
+  maxRow: 2047
+12:
+  minCol: 0
+  maxCol: 4095
+  minRow: 0
+  maxRow: 4095
+13:
+  minCol: 0
+  maxCol: 8191
+  minRow: 0
+  maxRow: 8191
+14:
+  minCol: 0
+  maxCol: 16383
+  minRow: 0
+  maxRow: 16383
+15:
+  minCol: 0
+  maxCol: 32767
+  minRow: 0
+  maxRow: 32767

--- a/internal/ogc/tiles/tileMatrixSetLimits/NetherlandsRDNewQuad.yaml
+++ b/internal/ogc/tiles/tileMatrixSetLimits/NetherlandsRDNewQuad.yaml
@@ -1,0 +1,85 @@
+0:
+  minCol: 0
+  maxCol: 0
+  minRow: 0
+  maxRow: 0
+1:
+  minCol: 0
+  maxCol: 1
+  minRow: 0
+  maxRow: 1
+2:
+  minCol: 0
+  maxCol: 3
+  minRow: 0
+  maxRow: 3
+3:
+  minCol: 0
+  maxCol: 7
+  minRow: 0
+  maxRow: 7
+4:
+  minCol: 0
+  maxCol: 15
+  minRow: 0
+  maxRow: 15
+5:
+  minCol: 0
+  maxCol: 31
+  minRow: 0
+  maxRow: 31
+6:
+  minCol: 0
+  maxCol: 63
+  minRow: 0
+  maxRow: 63
+7:
+  minCol: 0
+  maxCol: 127
+  minRow: 0
+  maxRow: 127
+8:
+  minCol: 0
+  maxCol: 255
+  minRow: 0
+  maxRow: 255
+9:
+  minCol: 0
+  maxCol: 511
+  minRow: 0
+  maxRow: 511
+10:
+  minCol: 0
+  maxCol: 1023
+  minRow: 0
+  maxRow: 1023
+11:
+  minCol: 0
+  maxCol: 2047
+  minRow: 0
+  maxRow: 2047
+12:
+  minCol: 0
+  maxCol: 4095
+  minRow: 0
+  maxRow: 4095
+13:
+  minCol: 0
+  maxCol: 8191
+  minRow: 0
+  maxRow: 8191
+14:
+  minCol: 0
+  maxCol: 16383
+  minRow: 0
+  maxRow: 16383
+15:
+  minCol: 0
+  maxCol: 32767
+  minRow: 0
+  maxRow: 32767
+16:
+  minCol: 0
+  maxCol: 65535
+  minRow: 0
+  maxRow: 65535

--- a/internal/ogc/tiles/tileMatrixSetLimits/WebMercatorQuad.yaml
+++ b/internal/ogc/tiles/tileMatrixSetLimits/WebMercatorQuad.yaml
@@ -1,0 +1,125 @@
+0:
+  minCol: 0
+  maxCol: 0
+  minRow: 0
+  maxRow: 0
+1:
+  minCol: 0
+  maxCol: 1
+  minRow: 0
+  maxRow: 1
+2:
+  minCol: 0
+  maxCol: 3
+  minRow: 0
+  maxRow: 3
+3:
+  minCol: 0
+  maxCol: 7
+  minRow: 0
+  maxRow: 7
+4:
+  minCol: 0
+  maxCol: 15
+  minRow: 0
+  maxRow: 15
+5:
+  minCol: 0
+  maxCol: 31
+  minRow: 0
+  maxRow: 31
+6:
+  minCol: 0
+  maxCol: 63
+  minRow: 0
+  maxRow: 63
+7:
+  minCol: 0
+  maxCol: 127
+  minRow: 0
+  maxRow: 127
+8:
+  minCol: 0
+  maxCol: 255
+  minRow: 0
+  maxRow: 255
+9:
+  minCol: 0
+  maxCol: 511
+  minRow: 0
+  maxRow: 511
+10:
+  minCol: 0
+  maxCol: 1023
+  minRow: 0
+  maxRow: 1023
+11:
+  minCol: 0
+  maxCol: 2047
+  minRow: 0
+  maxRow: 2047
+12:
+  minCol: 0
+  maxCol: 4095
+  minRow: 0
+  maxRow: 4095
+13:
+  minCol: 0
+  maxCol: 8191
+  minRow: 0
+  maxRow: 8191
+14:
+  minCol: 0
+  maxCol: 16383
+  minRow: 0
+  maxRow: 16383
+15:
+  minCol: 0
+  maxCol: 32767
+  minRow: 0
+  maxRow: 32767
+16:
+  minCol: 0
+  maxCol: 65535
+  minRow: 0
+  maxRow: 65535
+17:
+  minCol: 0
+  maxCol: 131071
+  minRow: 0
+  maxRow: 131071
+18:
+  minCol: 0
+  maxCol: 262143
+  minRow: 0
+  maxRow: 262143
+19:
+  minCol: 0
+  maxCol: 524287
+  minRow: 0
+  maxRow: 524287
+20:
+  minCol: 0
+  maxCol: 1048575
+  minRow: 0
+  maxRow: 1048575
+21:
+  minCol: 0
+  maxCol: 2097151
+  minRow: 0
+  maxRow: 2097151
+22:
+  minCol: 0
+  maxCol: 4194303
+  minRow: 0
+  maxRow: 4194303
+23:
+  minCol: 0
+  maxCol: 8388607
+  minRow: 0
+  maxRow: 8388607
+24:
+  minCol: 0
+  maxCol: 16777215
+  minRow: 0
+  maxRow: 16777215


### PR DESCRIPTION
# Description

- Add `tileMatrixSetLimits` to `/tiles`
- Add `tileMatrixSetURI` to `/tiles` for registered TileMatrixSets
- Correct `operationId` suffixes in `/api`
- Return HTTP 404 instead of HTTP 204 on out of bounds requests
- Add e2e-test for OGC API Tiles conformance

## Type of change

(Remove irrelevant options)

- New feature
- Improvement of existing feature
- Bugfix
- Refactoring

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR