### PR TITLE
Fix code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/internal/ogc/styles/templates/styles.go.html
+++ b/internal/ogc/styles/templates/styles.go.html
@@ -99,13 +99,13 @@
       const selectedProjection = value.proj;
       const urlHref = document.getElementById('href-url');
       const metadataHref = document.getElementById('href-metadata');
-      urlHref.textContent = '{{ $baseUrl }}/styles/' + selectedStyle;
-      urlHref.setAttribute('href', 'styles/' + selectedStyle);
-      metadataHref.setAttribute('href', 'styles/' + selectedStyle + '/metadata');
+      urlHref.textContent = '{{ $baseUrl }}/styles/' + encodeURIComponent(selectedStyle);
+      urlHref.setAttribute('href', 'styles/' + encodeURIComponent(selectedStyle));
+      metadataHref.setAttribute('href', 'styles/' + encodeURIComponent(selectedStyle) + '/metadata');
       // update style-url in app-vectortile-view
       const viewer = document.getElementById('styles-vectortile-view')
-      viewer.setAttribute('tile-url', '{{ $baseUrl }}/tiles/' + selectedProjection)
-      viewer.setAttribute('style-url', '{{ $baseUrl }}/styles/' + selectedStyle + '?f=mapbox')
+      viewer.setAttribute('tile-url', '{{ $baseUrl }}/tiles/' + encodeURIComponent(selectedProjection))
+      viewer.setAttribute('style-url', '{{ $baseUrl }}/styles/' + encodeURIComponent(selectedStyle) + '?f=mapbox')
     }, false);
   </script>
   <noscript>Enable Javascript to display vector tiles viewer</noscript>


### PR DESCRIPTION
Fixes [https://github.com/PDOK/gokoala/security/code-scanning/2](https://github.com/PDOK/gokoala/security/code-scanning/2)

To fix the problem, we need to ensure that any user input is properly sanitized or escaped before being used in the DOM. In this case, we should escape the `selectedStyle` variable before using it to construct the URL. This can be done using a function that ensures any special characters are properly encoded.

We will use JavaScript's `encodeURIComponent` function to escape the `selectedStyle` and `selectedProjection` values before using them in the URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
