### PR TITLE
Fix code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -49,8 +49,12 @@ declare global {
 Cypress.Commands.add('checkForBrokenLinks', () =>{
   cy.get('a').each(link => {
     const href = link.prop('href')
-    if (href && !href.includes('example.com') && !href.includes('europa.eu')) {
-      cy.request(href)
+    if (href) {
+      const host = new URL(href).host;
+      const allowedHosts = ['example.com', 'europa.eu'];
+      if (!allowedHosts.includes(host)) {
+        cy.request(href)
+      }
     }
   })
 })


### PR DESCRIPTION
Fixes [https://github.com/PDOK/gokoala/security/code-scanning/1](https://github.com/PDOK/gokoala/security/code-scanning/1)

To fix the problem, we need to parse the URL and check the host value against a whitelist of allowed hosts. This ensures that the check handles arbitrary subdomain sequences correctly and prevents bypassing the check by embedding the allowed host in an unexpected location.

1. Parse the URL to extract the host component.
2. Compare the host component against a whitelist of allowed hosts.
3. Update the code in `tests/cypress/support/commands.ts` to implement this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
