### PR TITLE
fix: correct path for tiles metadata breadcrumb, fixes JSON link

### DIFF
--- a/internal/ogc/tiles/main.go
+++ b/internal/ogc/tiles/main.go
@@ -355,7 +355,7 @@ func renderTilesTemplates(e *engine.Engine, collection *config.GeoSpatialCollect
 			projectionBreadcrumbs = append(projectionBreadcrumbs, []engine.Breadcrumb{
 				{
 					Name: projection,
-					Path: path,
+					Path: tilesLocalPath + projection,
 				},
 			}...)
 		}


### PR DESCRIPTION
# Description

Breadcrumb for `/tiles/<tileMatrixSetId>` had an incorrect path, resulting in 404s.

## Type of change

(Remove irrelevant options)

- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR