### PR TITLE
fix: re-enable tiles healthcheck

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/creasty/defaults"
@@ -219,21 +218,17 @@ type License struct {
 
 func setDefaults(config *Config) error {
 	// process 'default' tags
-	log.Println("Start setting defaults")
 	if err := defaults.Set(config); err != nil {
 		return fmt.Errorf("failed to set default configuration: %w", err)
 	}
 
 	// custom default logic
 	if len(config.AvailableLanguages) == 0 {
-		log.Println("Setting language defaults")
 		config.AvailableLanguages = append(config.AvailableLanguages, Language{language.Dutch}) // default to Dutch only
 	}
 	if config.OgcAPI.Tiles != nil {
-		log.Println("Setting tiles defaults")
 		config.OgcAPI.Tiles.Defaults()
 	}
-	log.Println("Done setting defaults")
 	return nil
 }
 

--- a/config/ogcapi_tiles.go
+++ b/config/ogcapi_tiles.go
@@ -25,6 +25,13 @@ func (o *OgcAPITiles) Defaults() {
 		o.DatasetTiles.HealthCheck.TilePath == nil {
 		log.Println("Setting dataset tiles healthcheck")
 		o.DatasetTiles.deriveHealthCheckTilePath()
+	} else if o.Collections != nil {
+		log.Println("Setting collection tiles healthcheck")
+		for _, coll := range o.Collections {
+			if coll.Tiles != nil && coll.Tiles.GeoDataTiles.HealthCheck.Srs == DefaultSrs && coll.Tiles.GeoDataTiles.HealthCheck.TilePath == nil {
+				coll.Tiles.GeoDataTiles.deriveHealthCheckTilePath()
+			}
+		}
 	}
 }
 

--- a/config/ogcapi_tiles.go
+++ b/config/ogcapi_tiles.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"log"
 	"slices"
 	"sort"
 
@@ -23,10 +22,8 @@ type OgcAPITiles struct {
 func (o *OgcAPITiles) Defaults() {
 	if o.DatasetTiles != nil && o.DatasetTiles.HealthCheck.Srs == DefaultSrs &&
 		o.DatasetTiles.HealthCheck.TilePath == nil {
-		log.Println("Setting dataset tiles healthcheck")
 		o.DatasetTiles.deriveHealthCheckTilePath()
 	} else if o.Collections != nil {
-		log.Println("Setting collection tiles healthcheck")
 		for _, coll := range o.Collections {
 			if coll.Tiles != nil && coll.Tiles.GeoDataTiles.HealthCheck.Srs == DefaultSrs && coll.Tiles.GeoDataTiles.HealthCheck.TilePath == nil {
 				coll.Tiles.GeoDataTiles.deriveHealthCheckTilePath()

--- a/internal/engine/health.go
+++ b/internal/engine/health.go
@@ -14,7 +14,7 @@ func newHealthEndpoint(e *Engine) {
 		switch {
 		case tilesConfig.DatasetTiles != nil:
 			target, err = url.Parse(tilesConfig.DatasetTiles.TileServer.String() + *tilesConfig.DatasetTiles.HealthCheck.TilePath)
-		case tilesConfig.Collections != nil && tilesConfig.Collections[0].Tiles != nil:
+		case len(tilesConfig.Collections) > 0 && tilesConfig.Collections[0].Tiles != nil:
 			target, err = url.Parse(tilesConfig.Collections[0].Tiles.GeoDataTiles.TileServer.String() + *tilesConfig.Collections[0].Tiles.GeoDataTiles.HealthCheck.TilePath)
 		default:
 			log.Println("cannot determine health check tilepath, falling back to basic check")

--- a/internal/engine/health.go
+++ b/internal/engine/health.go
@@ -1,11 +1,40 @@
 package engine
 
 import (
+	"log"
 	"net/http"
+	"net/url"
+	"time"
 )
 
 func newHealthEndpoint(e *Engine) {
-	e.Router.Get("/health", func(w http.ResponseWriter, _ *http.Request) {
-		SafeWrite(w.Write, []byte("OK"))
-	})
+	if tilesConfig := e.Config.OgcAPI.Tiles; tilesConfig != nil { //nolint:nestif
+		client := &http.Client{Timeout: time.Duration(500) * time.Millisecond}
+		var target *url.URL
+		var err error
+		if tilesConfig.DatasetTiles != nil {
+			target, err = url.Parse(tilesConfig.DatasetTiles.TileServer.String() + *tilesConfig.DatasetTiles.HealthCheck.TilePath)
+		} else if tilesConfig.Collections != nil {
+			target, err = url.Parse(tilesConfig.Collections[0].Tiles.GeoDataTiles.TileServer.String() + *tilesConfig.Collections[0].Tiles.GeoDataTiles.HealthCheck.TilePath)
+		}
+		if err != nil {
+			log.Fatalf("invalid health check tilepath: %v", err)
+		}
+
+		e.Router.Get("/health", func(w http.ResponseWriter, _ *http.Request) {
+			resp, err := client.Head(target.String())
+			if err != nil {
+				// exact error is irrelevant for health monitoring, but log it for insight
+				log.Printf("healthcheck failed: %v", err)
+				w.WriteHeader(http.StatusNotFound)
+			} else {
+				w.WriteHeader(resp.StatusCode)
+				resp.Body.Close()
+			}
+		})
+	} else {
+		e.Router.Get("/health", func(w http.ResponseWriter, _ *http.Request) {
+			SafeWrite(w.Write, []byte("OK"))
+		})
+	}
 }

--- a/internal/engine/health.go
+++ b/internal/engine/health.go
@@ -8,19 +8,23 @@ import (
 )
 
 func newHealthEndpoint(e *Engine) {
-	if tilesConfig := e.Config.OgcAPI.Tiles; tilesConfig != nil { //nolint:nestif
-		client := &http.Client{Timeout: time.Duration(500) * time.Millisecond}
-		var target *url.URL
+	var target *url.URL
+	if tilesConfig := e.Config.OgcAPI.Tiles; tilesConfig != nil {
 		var err error
-		if tilesConfig.DatasetTiles != nil {
+		switch {
+		case tilesConfig.DatasetTiles != nil:
 			target, err = url.Parse(tilesConfig.DatasetTiles.TileServer.String() + *tilesConfig.DatasetTiles.HealthCheck.TilePath)
-		} else if tilesConfig.Collections != nil {
+		case tilesConfig.Collections != nil && tilesConfig.Collections[0].Tiles != nil:
 			target, err = url.Parse(tilesConfig.Collections[0].Tiles.GeoDataTiles.TileServer.String() + *tilesConfig.Collections[0].Tiles.GeoDataTiles.HealthCheck.TilePath)
+		default:
+			log.Println("cannot determine health check tilepath, falling back to basic check")
 		}
 		if err != nil {
 			log.Fatalf("invalid health check tilepath: %v", err)
 		}
-
+	}
+	if target != nil {
+		client := &http.Client{Timeout: time.Duration(500) * time.Millisecond}
 		e.Router.Get("/health", func(w http.ResponseWriter, _ *http.Request) {
 			resp, err := client.Head(target.String())
 			if err != nil {


### PR DESCRIPTION
# Description

Add guard clause for the eventuality that `Collection.Tiles` struct is nil, refactor `newHealthEndpoint()` to fallback to basic endpoint when this occurs.

## Type of change

(Remove irrelevant options)

- Bugfix
- Refactoring

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR