### PR TITLE
fix: add custom JSON marshalling for inline structs

### DIFF
--- a/config/ogcapi_features.go
+++ b/config/ogcapi_features.go
@@ -101,7 +101,7 @@ func (c CollectionEntryFeatures) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c)
 }
 
-// UnmarshalJSON parses a string to OgcAPITiles
+// UnmarshalJSON parses a string to CollectionEntryFeatures
 func (c *CollectionEntryFeatures) UnmarshalJSON(b []byte) error {
 	return yaml.Unmarshal(b, c)
 }

--- a/config/ogcapi_features.go
+++ b/config/ogcapi_features.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/PDOK/gokoala/internal/engine/util"
 	"github.com/docker/go-units"
+	"gopkg.in/yaml.v3"
 )
 
 // +kubebuilder:object:generate=true
@@ -81,7 +83,7 @@ type CollectionEntryFeatures struct {
 
 	// Optional way to exclude feature properties and/or determine the ordering of properties in the response.
 	// +optional
-	FeatureProperties *FeatureProperties `yaml:",inline" json:",inline"`
+	*FeatureProperties `yaml:",inline" json:",inline"`
 
 	// Downloads available for this collection through map sheets. Note that 'map sheets' refer to a map
 	// divided in rectangle areas that can be downloaded individually.
@@ -91,6 +93,17 @@ type CollectionEntryFeatures struct {
 	// Configuration specifically related to HTML/Web representation
 	// +optional
 	Web *WebConfig `yaml:"web,omitempty" json:"web,omitempty"`
+}
+
+// MarshalJSON custom because inlining only works on embedded structs.
+// Value instead of pointer receiver because only that way it can be used for both.
+func (c CollectionEntryFeatures) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c)
+}
+
+// UnmarshalJSON parses a string to OgcAPITiles
+func (c *CollectionEntryFeatures) UnmarshalJSON(b []byte) error {
+	return yaml.Unmarshal(b, c)
 }
 
 // +kubebuilder:object:generate=true

--- a/config/ogcapi_tiles.go
+++ b/config/ogcapi_tiles.go
@@ -72,7 +72,7 @@ func (c CollectionEntryTiles) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// UnmarshalJSON parses a string to OgcAPITiles
+// UnmarshalJSON parses a string to CollectionEntryTiles
 func (c *CollectionEntryTiles) UnmarshalJSON(b []byte) error {
 	return yaml.Unmarshal(b, c)
 }

--- a/config/ogcapi_tiles.go
+++ b/config/ogcapi_tiles.go
@@ -1,11 +1,13 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 	"sort"
 
 	"github.com/PDOK/gokoala/internal/engine/util"
+	"gopkg.in/yaml.v3"
 )
 
 // +kubebuilder:object:generate=true
@@ -17,6 +19,25 @@ type OgcAPITiles struct {
 	// Tiles per collection. When no collections are specified tiles should be hosted at the root of the API (/tiles endpoint).
 	// +optional
 	Collections GeoSpatialCollections `yaml:"collections,omitempty" json:"collections,omitempty"`
+}
+
+type OgcAPITilesJSON struct {
+	*Tiles      `json:",inline"`
+	Collections GeoSpatialCollections `json:"collections,omitempty"`
+}
+
+// MarshalJSON custom because inlining only works on embedded structs.
+// Value instead of pointer receiver because only that way it can be used for both.
+func (o OgcAPITiles) MarshalJSON() ([]byte, error) {
+	return json.Marshal(OgcAPITilesJSON{
+		Tiles:       o.DatasetTiles,
+		Collections: o.Collections,
+	})
+}
+
+// UnmarshalJSON parses a string to OgcAPITiles
+func (o *OgcAPITiles) UnmarshalJSON(b []byte) error {
+	return yaml.Unmarshal(b, o)
 }
 
 func (o *OgcAPITiles) Defaults() {
@@ -37,6 +58,23 @@ type CollectionEntryTiles struct {
 
 	// Tiles specific to this collection. Called 'geodata tiles' in OGC spec.
 	GeoDataTiles Tiles `yaml:",inline" json:",inline" validate:"required"`
+}
+
+type CollectionEntryTilesJSON struct {
+	Tiles `json:",inline"`
+}
+
+// MarshalJSON custom because inlining only works on embedded structs.
+// Value instead of pointer receiver because only that way it can be used for both.
+func (c CollectionEntryTiles) MarshalJSON() ([]byte, error) {
+	return json.Marshal(CollectionEntryTilesJSON{
+		Tiles: c.GeoDataTiles,
+	})
+}
+
+// UnmarshalJSON parses a string to OgcAPITiles
+func (c *CollectionEntryTiles) UnmarshalJSON(b []byte) error {
+	return yaml.Unmarshal(b, c)
 }
 
 // +kubebuilder:validation:Enum=raster;vector


### PR DESCRIPTION
# Description

Inlining only works on embedded structs, this caused issues in the`ogcapi-operator`. Added specific JSON marshalling functions for the offending structs to avoid the issue.

## Type of change

- Bugfix
- Refactoring
- Configuration change

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR