### PR TITLE
feat(config): add validation on configured tiles projections

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -256,8 +256,16 @@ func validate(config *Config) error {
 	}
 
 	// custom validations
+	var errs []error
 	if config.OgcAPI.Features != nil {
-		return validateFeatureCollections(config.OgcAPI.Features.Collections)
+		errs = append(errs, validateFeatureCollections(config.OgcAPI.Features.Collections))
+	}
+	if config.OgcAPI.Tiles != nil {
+		errs = append(errs, validateTileProjections(config.OgcAPI.Tiles))
+	}
+	err = errors.Join(errs...)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -68,6 +68,14 @@ func TestNewConfig(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "fail on invalid config with unsupported tile projection",
+			args: args{
+				configFile: "internal/engine/testdata/config_invalid_tiles_projection.yaml",
+			},
+			wantErr:    true,
+			wantErrMsg: "validation failed for srs 'EPSG:99999'; srs is not supported",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/config/ogcapi_tiles.go
+++ b/config/ogcapi_tiles.go
@@ -235,3 +235,25 @@ type HealthCheck struct {
 	// +optional
 	TilePath *string `yaml:"tilePath,omitempty" json:"tilePath,omitempty" validate:"required_unless=Srs EPSG:28992"`
 }
+
+func validateTileProjections(tiles *OgcAPITiles) error {
+	var errMessages []string
+	if tiles.DatasetTiles != nil {
+		for _, srs := range tiles.DatasetTiles.SupportedSrs {
+			if _, ok := AllTileProjections[srs.Srs]; !ok {
+				errMessages = append(errMessages, fmt.Sprintf("validation failed for srs '%s'; srs is not supported", srs.Srs))
+			}
+		}
+	}
+	for _, collection := range tiles.Collections {
+		for _, srs := range collection.Tiles.GeoDataTiles.SupportedSrs {
+			if _, ok := AllTileProjections[srs.Srs]; !ok {
+				errMessages = append(errMessages, fmt.Sprintf("validation failed for srs '%s'; srs is not supported", srs.Srs))
+			}
+		}
+	}
+	if len(errMessages) > 0 {
+		return fmt.Errorf("invalid config provided:\n%v", errMessages)
+	}
+	return nil
+}

--- a/internal/engine/testdata/config_invalid_tiles_projection.yaml
+++ b/internal/engine/testdata/config_invalid_tiles_projection.yaml
@@ -1,0 +1,24 @@
+---
+version: 1.0.0
+title: Invalid config file
+abstract: Invalid collection IDs
+baseUrl: http://test.example
+serviceIdentifier: Min
+license:
+  name: MIT
+  url: https://www.tldrlegal.com/license/mit-license
+ogcApi:
+  tiles:
+    tileServer:
+      http://localhost:9090
+    types:
+      - vector
+    supportedSrs:
+      - srs: EPSG:28992
+        zoomLevelRange:
+          start: 0
+          end: 12
+      - srs: EPSG:99999
+        zoomLevelRange:
+          start: 0
+          end: 30


### PR DESCRIPTION
# Description

Add validation on configured Tiles projections, fail on unsupported projections. As a result of #287.

## Type of change

- New feature

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR