### PR TITLE
fix: render zoom level 11 correctly in TileJSON.

### DIFF
--- a/internal/ogc/tiles/templates/tiles/EuropeanETRS89_LAEAQuad.go.tilejson
+++ b/internal/ogc/tiles/templates/tiles/EuropeanETRS89_LAEAQuad.go.tilejson
@@ -176,7 +176,7 @@
       ]
     }
     {{end}}
-    {{ if and (le $type.ZoomLevelRange.Start 11) (ge $type.ZoomLevelRange.End 12) }}
+    {{ if and (le $type.ZoomLevelRange.Start 11) (ge $type.ZoomLevelRange.End 11) }}
     {{ if not $first }}, {{else}} {{$first = false}} {{end}}
     {
       "id": "11",

--- a/internal/ogc/tiles/templates/tiles/NetherlandsRDNewQuad.go.tilejson
+++ b/internal/ogc/tiles/templates/tiles/NetherlandsRDNewQuad.go.tilejson
@@ -176,7 +176,7 @@
       ]
     }
     {{end}}
-    {{ if and (le $type.ZoomLevelRange.Start 11) (ge $type.ZoomLevelRange.End 12) }}
+    {{ if and (le $type.ZoomLevelRange.Start 11) (ge $type.ZoomLevelRange.End 11) }}
     {{ if not $first }}, {{else}} {{$first = false}} {{end}}
     {
       "id": "11",

--- a/internal/ogc/tiles/templates/tiles/WebMercatorQuad.go.tilejson
+++ b/internal/ogc/tiles/templates/tiles/WebMercatorQuad.go.tilejson
@@ -176,7 +176,7 @@
       ]
     }
     {{end}}
-    {{ if and (le $type.ZoomLevelRange.Start 11) (ge $type.ZoomLevelRange.End 12) }}
+    {{ if and (le $type.ZoomLevelRange.Start 11) (ge $type.ZoomLevelRange.End 11) }}
     {{ if not $first }}, {{else}} {{$first = false}} {{end}}
     {
       "id": "11",


### PR DESCRIPTION
# Description

Render zoom level 11 correctly in TileJSON 

## Type of change

- Bugfix

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR