### PR TITLE
fix: map date columns (= without time component) as actual dates, not timestamps with the time set to zero.

### DIFF
--- a/internal/engine/types/date.go
+++ b/internal/engine/types/date.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"encoding/json"
+	"time"
+)
+
+func NewDate(t time.Time) Date {
+	return Date{t}
+}
+
+type Date struct {
+	time time.Time
+}
+
+// MarshalJSON turn Date into JSON
+// Value instead of pointer receiver because only that way it can be used for both.
+func (d Date) MarshalJSON() ([]byte, error) {
+	if d.time.IsZero() {
+		return json.Marshal(nil)
+	}
+	return json.Marshal(d.time.Format(time.DateOnly))
+}
+
+// UnmarshalJSON turn JSON into Date
+func (d *Date) UnmarshalJSON(text []byte) (err error) {
+	var value string
+	err = json.Unmarshal(text, &value)
+	if err != nil {
+		return err
+	}
+	if value == "" {
+		return nil
+	}
+	d.time, err = time.Parse(time.DateOnly, value)
+	return err
+}
+
+func (d Date) String() string {
+	if d.time.IsZero() {
+		return ""
+	}
+	return d.time.Format(time.DateOnly)
+}

--- a/internal/engine/types/date_test.go
+++ b/internal/engine/types/date_test.go
@@ -1,0 +1,264 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    time.Time
+		expected Date
+	}{
+		{
+			name:     "valid date",
+			input:    time.Date(2023, 12, 25, 0, 0, 0, 0, time.UTC),
+			expected: Date{time: time.Date(2023, 12, 25, 0, 0, 0, 0, time.UTC)},
+		},
+		{
+			name:     "zero date",
+			input:    time.Time{},
+			expected: Date{time: time.Time{}},
+		},
+		{
+			name:     "date with time component",
+			input:    time.Date(2023, 12, 25, 15, 30, 45, 123456789, time.UTC),
+			expected: Date{time: time.Date(2023, 12, 25, 15, 30, 45, 123456789, time.UTC)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewDate(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDate_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		date     Date
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "valid date",
+			date:     NewDate(time.Date(2023, 12, 25, 0, 0, 0, 0, time.UTC)),
+			expected: `"2023-12-25"`,
+			wantErr:  false,
+		},
+		{
+			name:     "zero date",
+			date:     NewDate(time.Time{}),
+			expected: "null",
+			wantErr:  false,
+		},
+		{
+			name:     "date with time component",
+			date:     NewDate(time.Date(2023, 12, 25, 15, 30, 45, 0, time.UTC)),
+			expected: `"2023-12-25"`,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.date.MarshalJSON()
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.JSONEq(t, tt.expected, string(result))
+		})
+	}
+}
+
+func TestDate_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected Date
+		wantErr  bool
+	}{
+		{
+			name:     "valid date",
+			input:    `"2023-12-25"`,
+			expected: NewDate(time.Date(2023, 12, 25, 0, 0, 0, 0, time.UTC)),
+			wantErr:  false,
+		},
+		{
+			name:     "empty string",
+			input:    `""`,
+			expected: Date{},
+			wantErr:  false,
+		},
+		{
+			name:     "null value",
+			input:    "null",
+			expected: Date{},
+			wantErr:  false,
+		},
+		{
+			name:     "invalid date format",
+			input:    `"2023/12/25"`,
+			expected: Date{},
+			wantErr:  true,
+		},
+		{
+			name:     "invalid date value",
+			input:    `"2023-13-45"`,
+			expected: Date{},
+			wantErr:  true,
+		},
+		{
+			name:     "datetime string",
+			input:    `"2023-12-25T15:30:45Z"`,
+			expected: Date{},
+			wantErr:  true,
+		},
+		{
+			name:     "invalid JSON",
+			input:    `"2023-12-25`,
+			expected: Date{},
+			wantErr:  true,
+		},
+		{
+			name:     "number instead of string",
+			input:    `12345`,
+			expected: Date{},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result Date
+			err := result.UnmarshalJSON([]byte(tt.input))
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDate_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		date     Date
+		expected string
+	}{
+		{
+			name:     "valid date",
+			date:     NewDate(time.Date(2023, 12, 25, 0, 0, 0, 0, time.UTC)),
+			expected: "2023-12-25",
+		},
+		{
+			name:     "zero date",
+			date:     NewDate(time.Time{}),
+			expected: "",
+		},
+		{
+			name:     "date with time component",
+			date:     NewDate(time.Date(2023, 12, 25, 15, 30, 45, 0, time.UTC)),
+			expected: "2023-12-25",
+		},
+		{
+			name:     "single digit month and day",
+			date:     NewDate(time.Date(2023, 1, 5, 0, 0, 0, 0, time.UTC)),
+			expected: "2023-01-05",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.date.String()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDate_JSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		date Date
+	}{
+		{
+			name: "valid date",
+			date: NewDate(time.Date(2023, 12, 25, 0, 0, 0, 0, time.UTC)),
+		},
+		{
+			name: "zero date",
+			date: NewDate(time.Time{}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonData, err := json.Marshal(tt.date)
+			assert.NoError(t, err)
+			var result Date
+			err = json.Unmarshal(jsonData, &result)
+			assert.NoError(t, err)
+
+			// For zero dates, both should be zero
+			if tt.date.time.IsZero() {
+				assert.True(t, result.time.IsZero())
+			} else {
+				// For non-zero dates, should match the date part only
+				assert.Equal(t, tt.date.time.Format(time.DateOnly), result.time.Format(time.DateOnly))
+			}
+		})
+	}
+}
+
+func TestDate_StructMarshaling(t *testing.T) {
+	type TestStruct struct {
+		Date         Date   `json:"date"`
+		Name         string `json:"name"`
+		OptionalDate *Date  `json:"optionalDate,omitempty"`
+	}
+
+	tests := []struct {
+		name     string
+		input    TestStruct
+		expected string
+	}{
+		{
+			name: "valid date",
+			input: TestStruct{
+				Date: NewDate(time.Date(2023, 12, 25, 0, 0, 0, 0, time.UTC)),
+				Name: "test",
+			},
+			expected: `{"date":"2023-12-25","name":"test"}`,
+		},
+		{
+			name: "zero date",
+			input: TestStruct{
+				Date: NewDate(time.Time{}),
+				Name: "test",
+			},
+			expected: `{"date":null,"name":"test"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := json.Marshal(tt.input)
+			assert.NoError(t, err)
+			assert.JSONEq(t, tt.expected, string(result))
+		})
+	}
+}

--- a/internal/engine/types/util.go
+++ b/internal/engine/types/util.go
@@ -1,0 +1,13 @@
+package types
+
+import "time"
+
+// IsDate return true when time.Time doesn't contain a time component, false otherwise
+func IsDate(t time.Time) bool {
+	return t.Hour() == 0 && t.Minute() == 0 && t.Second() == 0
+}
+
+// IsFloat return true when float has decimals, false otherwise
+func IsFloat(f float64) bool {
+	return f != float64(int64(f))
+}

--- a/internal/ogc/features/datasources/geopackage/metadata.go
+++ b/internal/ogc/features/datasources/geopackage/metadata.go
@@ -1,15 +1,35 @@
 package geopackage
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/PDOK/gokoala/config"
 	ds "github.com/PDOK/gokoala/internal/ogc/features/datasources"
 	d "github.com/PDOK/gokoala/internal/ogc/features/domain"
 	"github.com/jmoiron/sqlx"
 )
+
+// featureTable according to spec https://www.geopackage.org/spec121/index.html#_contents
+type featureTable struct {
+	TableName          string          `db:"table_name"`
+	DataType           string          `db:"data_type"` // always 'features'
+	Identifier         string          `db:"identifier"`
+	Description        string          `db:"description"`
+	GeometryColumnName string          `db:"column_name"`
+	GeometryType       string          `db:"geometry_type_name"`
+	LastChange         time.Time       `db:"last_change"`
+	MinX               sql.NullFloat64 `db:"min_x"` // bbox
+	MinY               sql.NullFloat64 `db:"min_y"` // bbox
+	MaxX               sql.NullFloat64 `db:"max_x"` // bbox
+	MaxY               sql.NullFloat64 `db:"max_y"` // bbox
+	SRS                sql.NullInt64   `db:"srs_id"`
+
+	Schema *d.Schema // required
+}
 
 // Read metadata about gpkg and sqlite driver
 func readDriverMetadata(db *sqlx.DB) (string, error) {

--- a/internal/ogc/features/domain/mapper.go
+++ b/internal/ogc/features/domain/mapper.go
@@ -155,7 +155,7 @@ func mapColumnsToFeature(ctx context.Context, firstRow bool, feature *Feature, c
 				}
 			case time.Time:
 				// Map as date (= without time) only when defined as such in the schema AND when no time component is present
-				if t := schema.GetType(columnName); t.Format == formatDateOnly && types.IsDate(v) {
+				if types.IsDate(v) && schema.IsDate(columnName) {
 					feature.Properties.Set(columnName, types.NewDate(v))
 				} else {
 					feature.Properties.Set(columnName, v)

--- a/internal/ogc/features/domain/mapper_test.go
+++ b/internal/ogc/features/domain/mapper_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/PDOK/gokoala/internal/engine/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/twpayne/go-geom"
 	"github.com/twpayne/go-geom/encoding/geojson"
@@ -32,6 +33,7 @@ func TestMapColumnsToFeature(t *testing.T) {
 		fidColumn        string
 		externalFidCol   string
 		geomColumn       string
+		schemaFields     []Field
 		mapGeom          MapGeom
 		expectedFeature  *Feature
 		expectedPrevNext *PrevNextFID
@@ -107,11 +109,52 @@ func TestMapColumnsToFeature(t *testing.T) {
 			expectedFeature:  &Feature{Properties: NewFeaturePropertiesWithData(false, map[string]any{"float_col": int64(376422001)})},
 			expectedPrevNext: &PrevNextFID{},
 		},
+		{
+			name:    "Test date is mapped without time component",
+			feature: &Feature{Properties: NewFeatureProperties(false)},
+			columns: []string{"date_col", "time_col", "date_not_in_schema", "invalid_date_with_timestamp"},
+			values: []any{
+				time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),  // date_col
+				time.Date(2020, 1, 1, 12, 4, 6, 8, time.UTC), // time_col
+				time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),  // date_col_not_in_schema
+				time.Date(2020, 1, 1, 12, 4, 6, 8, time.UTC), // invalid_date_with_timestamp
+			},
+			schemaFields: []Field{
+				{
+					Name: "date_col",
+					Type: "date",
+				},
+				{
+					Name: "time_col",
+					Type: "datetime",
+				},
+				{
+					Name: "date_not_in_schema",
+					Type: "datetime", // marked as datetime instead of date
+				},
+				{
+					Name: "invalid_date_with_timestamp",
+					Type: "date",
+				},
+			},
+			expectedFeature: &Feature{Properties: NewFeaturePropertiesWithData(false, map[string]any{
+				"date_col":                    types.NewDate(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)),
+				"time_col":                    time.Date(2020, 1, 1, 12, 4, 6, 8, time.UTC),
+				"date_not_in_schema":          time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+				"invalid_date_with_timestamp": time.Date(2020, 1, 1, 12, 4, 6, 8, time.UTC),
+			})},
+			expectedPrevNext: &PrevNextFID{},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prevNextID, err := mapColumnsToFeature(t.Context(), tt.firstRow, tt.feature, tt.columns, tt.values, tt.fidColumn, tt.externalFidCol, tt.geomColumn, tt.mapGeom, nil)
+			schema, err := NewSchema([]Field{}, tt.fidColumn, tt.externalFidCol)
+			assert.NoError(t, err)
+			if tt.schemaFields != nil {
+				schema.Fields = tt.schemaFields
+			}
+			prevNextID, err := mapColumnsToFeature(t.Context(), tt.firstRow, tt.feature, tt.columns, tt.values, tt.fidColumn, tt.externalFidCol, tt.geomColumn, schema, tt.mapGeom, nil)
 
 			if tt.expectedError != nil {
 				assert.Nil(t, prevNextID)

--- a/internal/ogc/features/domain/schema.go
+++ b/internal/ogc/features/domain/schema.go
@@ -8,6 +8,12 @@ import (
 )
 
 const (
+	formatDateOnly = "date"
+	formatTimeOnly = "time"
+	formatDateTime = "date-time"
+)
+
+const (
 	MinxField = "minx"
 	MinyField = "miny"
 	MaxxField = "maxx"
@@ -80,7 +86,7 @@ type Schema struct {
 	Fields []Field
 }
 
-// HasExternalFid convenience function
+// HasExternalFid convenience function to check if this schema defines an external feature ID
 func (s Schema) HasExternalFid() bool {
 	for _, field := range s.Fields {
 		if field.IsExternalFid {
@@ -88,6 +94,16 @@ func (s Schema) HasExternalFid() bool {
 		}
 	}
 	return false
+}
+
+// GetType convenience function to get TypeFormat of field
+func (s Schema) GetType(field string) TypeFormat {
+	for _, f := range s.Fields {
+		if f.Name == field {
+			return f.ToTypeFormat()
+		}
+	}
+	return TypeFormat{}
 }
 
 // Field a field/column/property in the schema. Contains at least a name and data type.
@@ -113,16 +129,17 @@ type TypeFormat struct {
 // ToTypeFormat converts the Field's data type (from SQLite or Postgres) to a valid JSON data type
 // and optional format as specified in OAF Part 5.
 func (f Field) ToTypeFormat() TypeFormat {
-	lowerCaseType := strings.ToLower(f.Type)
+	// lowercase, no spaces
+	normalizedType := strings.ReplaceAll(strings.ToLower(f.Type), " ", "")
 
-	switch lowerCaseType {
+	switch normalizedType {
 	case "boolean", "bool":
 		return TypeFormat{Type: "boolean"}
 	case "text", "char", "character", "character varying", "varchar", "nvarchar", "clob":
 		return TypeFormat{Type: "string"}
 	case "int", "integer", "tinyint", "smallint", "mediumint", "bigint", "int2", "int8":
 		return TypeFormat{Type: "integer"}
-	case "real", "float", "double", "double precision", "numeric", "decimal":
+	case "real", "float", "double", "doubleprecision", "numeric", "decimal":
 		return TypeFormat{Type: "number", Format: "double"}
 	case "uuid":
 		// From OAF Part 5: Properties that represent a UUID SHOULD be represented as a string with format "uuid".
@@ -130,23 +147,28 @@ func (f Field) ToTypeFormat() TypeFormat {
 	case "date":
 		// From OAF Part 5: Each temporal property SHALL be a "string" literal with the appropriate format
 		// (e.g., "date-time" or "date" for instances, depending on the temporal granularity).
-		return TypeFormat{Type: "string", Format: "date"}
+		return TypeFormat{Type: "string", Format: formatDateOnly}
 	case "time":
 		// From OAF Part 5: Each temporal property SHALL be a "string" literal with the appropriate format
 		// (e.g., "date-time" or "date" for instances, depending on the temporal granularity).
-		return TypeFormat{Type: "string", Format: "time"}
+		return TypeFormat{Type: "string", Format: formatTimeOnly}
 	case "datetime", "timestamp":
 		// From OAF Part 5: Each temporal property SHALL be a "string" literal with the appropriate format
 		// (e.g., "date-time" or "date" for instances, depending on the temporal granularity).
-		return TypeFormat{Type: "string", Format: "date-time"}
+		return TypeFormat{Type: "string", Format: formatDateTime}
 	case geometryType, geometryCollectionType:
 		// From OAF Part 5: the following special value is supported: "geometry-any" as the wildcard for any geometry type
-		return TypeFormat{Type: lowerCaseType, Format: "geometry-any"}
+		return TypeFormat{Type: normalizedType, Format: "geometry-any"}
 	case pointType, linestringType, polygonType, multipointType, multilinestringType, multipolygonType:
 		// From OAF Part 5: Each spatial property SHALL include a "format" member with a string value "geometry",
 		// followed by a hyphen, followed by the name of the geometry type in lower case
-		return TypeFormat{Type: lowerCaseType, Format: "geometry-" + lowerCaseType}
+		return TypeFormat{Type: normalizedType, Format: "geometry-" + normalizedType}
 	default:
+		if strings.Contains(normalizedType, "text(") || strings.Contains(normalizedType, "varchar(") {
+			// Sometimes datasources mention the length of fields, this is irrelevant.
+			// Also, SQLite accepts for example TEXT(5) but ignores the length: https://sqlite.org/datatype3.html#affinity_name_examples
+			return TypeFormat{Type: "string"}
+		}
 		log.Printf("Warning: unknown data type '%s' for field '%s', falling back to string", f.Type, f.Name)
 		return TypeFormat{Type: "string"}
 	}

--- a/internal/ogc/features/domain/schema.go
+++ b/internal/ogc/features/domain/schema.go
@@ -106,6 +106,12 @@ func (s Schema) GetType(field string) TypeFormat {
 	return TypeFormat{}
 }
 
+// IsDate convenience function to check if field is a Date
+func (s Schema) IsDate(field string) bool {
+	t := s.GetType(field)
+	return t.Format == formatDateOnly
+}
+
 // Field a field/column/property in the schema. Contains at least a name and data type.
 type Field struct {
 	Name        string // required

--- a/internal/ogc/features/templates/schema.go.html
+++ b/internal/ogc/features/templates/schema.go.html
@@ -29,6 +29,8 @@
                 <td class="text-wrap">{{ i18n "FeatureIdDescription"}}{{ if .Params.HasExternalFid }} {{ i18n "FeatureIdStableOverTime"}}{{ end }}</td>
             </tr>
             {{ range $feat := .Params.Fields }}
+                {{ $typeFormat := $feat.ToTypeFormat }}
+
                 {{/* Skip feature id and external feature id fields, since we don't include those directly. We always use an 'id' field (as required by GeoJSON / JSON-FG).*/}}
                 {{ if $feat.IsFid }}
                     {{ continue }}
@@ -41,14 +43,14 @@
                     {{/* Just like 'id', we call the geometry field always 'geometry' regardless of the column name in the data source */}}
                     <tr>
                         <td class="text-nowrap">geometry</td>
-                        <td class="text-nowrap">{{ $feat.ToTypeFormat.Type }}</td>
+                        <td class="text-nowrap">{{ $typeFormat.Type }}</td>
                         <td class="text-nowrap">{{ if $feat.IsRequired }}{{ i18n "RequiredYes"}}{{ else }}{{ i18n "RequiredNo" }}{{ end }}</td>
                         <td class="text-wrap">{{ $feat.Description }}</td>
                     </tr>
                 {{ else }}
                     <tr>
                         <td class="text-nowrap">{{ $feat.Name }}</td>
-                        <td class="text-nowrap">{{ $feat.ToTypeFormat.Type }}</td>
+                        <td class="text-nowrap">{{ if $typeFormat.Format }}{{ $typeFormat.Format }}{{ else }}{{ $typeFormat.Type }}{{ end }}</td>
                         <td class="text-nowrap">{{ if $feat.IsRequired }}{{ i18n "RequiredYes"}}{{ else }}{{ i18n "RequiredNo" }}{{ end }}</td>
                         <td class="text-wrap">
                             {{ if $feat.IsPrimaryIntervalStart }}

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -49,7 +49,7 @@ declare global {
 Cypress.Commands.add('checkForBrokenLinks', () =>{
   cy.get('a').each(link => {
     const href = link.prop('href')
-    if (href && !href.includes('example.com') && !href.includes('europa.eu')) {
+    if (href && !href.includes('example.com') && !href.includes('europa.eu') && !href.includes('opengis.net/spec')) {
       cy.request(href)
     }
   })


### PR DESCRIPTION
# Description

map date columns (= without time component) as actual dates, not timestamps with the time set to zero.

## Type of change

- Bug fix
- Potential breaking change

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR