### PR TITLE
fix: swap xy when required

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,10 @@ ENV GOOS=linux
 # install sqlite-related compile-time dependencies
 RUN set -eux && \
     apt-get update && \
-    apt-get install --no-install-recommends -y libcurl4-openssl-dev=* libssl-dev=* libsqlite3-mod-spatialite=* && \
+    apt-get install --no-install-recommends -y  \
+      libcurl4-openssl-dev=*  \
+      libssl-dev=*  \
+      libsqlite3-mod-spatialite=* && \
     rm -rf /var/lib/apt/lists/*
 
 # install controller-gen (used by go generate)
@@ -41,7 +44,13 @@ FROM docker.io/debian:bookworm-slim
 # install sqlite-related runtime dependencies
 RUN set -eux && \
     apt-get update && \
-    apt-get install --no-install-recommends -y libcurl4=* curl=* openssl=* ca-certificates=* libsqlite3-mod-spatialite=* && \
+    apt-get install --no-install-recommends -y  \
+      libcurl4=*  \
+      curl=*  \
+      openssl=*  \
+      ca-certificates=*  \
+      libsqlite3-mod-spatialite=* \
+      proj-bin=* && \
     rm -rf /var/lib/apt/lists/*
 
 EXPOSE 8080

--- a/internal/ogc/features/datasources/datasource.go
+++ b/internal/ogc/features/datasources/datasource.go
@@ -44,8 +44,8 @@ type FeaturesCriteria struct {
 	Limit  int
 
 	// multiple projections support (OAF part 2)
-	InputSRID  int // derived from bbox or filter param when available, or WGS84 as default
-	OutputSRID int // derived from crs param when available, or WGS84 as default
+	InputSRID  domain.SRID // derived from bbox or filter param when available, or WGS84 as default
+	OutputSRID domain.SRID // derived from crs param when available, or WGS84 as default
 
 	// filtering by bounding box (OAF part 1)
 	Bbox *geom.Bounds

--- a/internal/ogc/features/datasources/datasource.go
+++ b/internal/ogc/features/datasources/datasource.go
@@ -18,13 +18,13 @@ type Datasource interface {
 	GetFeatureIDs(ctx context.Context, collection string, criteria FeaturesCriteria) ([]int64, domain.Cursors, error)
 
 	// GetFeaturesByID returns a collection of Features with the given IDs. To be used in concert with GetFeatureIDs
-	GetFeaturesByID(ctx context.Context, collection string, featureIDs []int64, swapXY bool, profile domain.Profile) (*domain.FeatureCollection, error)
+	GetFeaturesByID(ctx context.Context, collection string, featureIDs []int64, axisOrder domain.AxisOrder, profile domain.Profile) (*domain.FeatureCollection, error)
 
 	// GetFeatures returns all Features matching the given criteria and Cursors for pagination
-	GetFeatures(ctx context.Context, collection string, criteria FeaturesCriteria, swapXY bool, profile domain.Profile) (*domain.FeatureCollection, domain.Cursors, error)
+	GetFeatures(ctx context.Context, collection string, criteria FeaturesCriteria, axisOrder domain.AxisOrder, profile domain.Profile) (*domain.FeatureCollection, domain.Cursors, error)
 
 	// GetFeature returns a specific Feature, based on its feature id
-	GetFeature(ctx context.Context, collection string, featureID any, swapXY bool, profile domain.Profile) (*domain.Feature, error)
+	GetFeature(ctx context.Context, collection string, featureID any, axisOrder domain.AxisOrder, profile domain.Profile) (*domain.Feature, error)
 
 	// GetSchema returns the schema (fields, data types, descriptions, etc.) of the table associated with the given collection
 	GetSchema(collection string) (*domain.Schema, error)

--- a/internal/ogc/features/datasources/datasource.go
+++ b/internal/ogc/features/datasources/datasource.go
@@ -46,6 +46,7 @@ type FeaturesCriteria struct {
 	// multiple projections support (OAF part 2)
 	InputSRID  domain.SRID // derived from bbox or filter param when available, or WGS84 as default
 	OutputSRID domain.SRID // derived from crs param when available, or WGS84 as default
+	SwapXY     bool        // XY = false, YX = true
 
 	// filtering by bounding box (OAF part 1)
 	Bbox *geom.Bounds

--- a/internal/ogc/features/datasources/datasource.go
+++ b/internal/ogc/features/datasources/datasource.go
@@ -18,13 +18,13 @@ type Datasource interface {
 	GetFeatureIDs(ctx context.Context, collection string, criteria FeaturesCriteria) ([]int64, domain.Cursors, error)
 
 	// GetFeaturesByID returns a collection of Features with the given IDs. To be used in concert with GetFeatureIDs
-	GetFeaturesByID(ctx context.Context, collection string, featureIDs []int64, profile domain.Profile) (*domain.FeatureCollection, error)
+	GetFeaturesByID(ctx context.Context, collection string, featureIDs []int64, swapXY bool, profile domain.Profile) (*domain.FeatureCollection, error)
 
 	// GetFeatures returns all Features matching the given criteria and Cursors for pagination
-	GetFeatures(ctx context.Context, collection string, criteria FeaturesCriteria, profile domain.Profile) (*domain.FeatureCollection, domain.Cursors, error)
+	GetFeatures(ctx context.Context, collection string, criteria FeaturesCriteria, swapXY bool, profile domain.Profile) (*domain.FeatureCollection, domain.Cursors, error)
 
 	// GetFeature returns a specific Feature, based on its feature id
-	GetFeature(ctx context.Context, collection string, featureID any, profile domain.Profile) (*domain.Feature, error)
+	GetFeature(ctx context.Context, collection string, featureID any, swapXY bool, profile domain.Profile) (*domain.Feature, error)
 
 	// GetSchema returns the schema (fields, data types, descriptions, etc.) of the table associated with the given collection
 	GetSchema(collection string) (*domain.Schema, error)
@@ -46,7 +46,6 @@ type FeaturesCriteria struct {
 	// multiple projections support (OAF part 2)
 	InputSRID  domain.SRID // derived from bbox or filter param when available, or WGS84 as default
 	OutputSRID domain.SRID // derived from crs param when available, or WGS84 as default
-	SwapXY     bool        // XY = false, YX = true
 
 	// filtering by bounding box (OAF part 1)
 	Bbox *geom.Bounds

--- a/internal/ogc/features/datasources/geopackage/geopackage_test.go
+++ b/internal/ogc/features/datasources/geopackage/geopackage_test.go
@@ -335,7 +335,7 @@ func TestGeoPackage_GetFeatures(t *testing.T) {
 			g.preparedStmtCache = NewCache()
 			url, _ := neturl.Parse("http://example.com")
 			p := domain.NewProfile(domain.RelAsLink, *url, []string{})
-			fc, cursor, err := g.GetFeatures(tt.args.ctx, tt.args.collection, tt.args.queryParams, p)
+			fc, cursor, err := g.GetFeatures(tt.args.ctx, tt.args.collection, tt.args.queryParams, false, p)
 			if err != nil {
 				if !tt.wantErr {
 					t.Errorf("GetFeatures, error %v, wantErr %v", err, tt.wantErr)
@@ -442,7 +442,7 @@ func TestGeoPackage_GetFeature(t *testing.T) {
 			}
 			url, _ := neturl.Parse("http://example.com")
 			p := domain.NewProfile(domain.RelAsLink, *url, []string{})
-			got, err := g.GetFeature(tt.args.ctx, tt.args.collection, tt.args.featureID, p)
+			got, err := g.GetFeature(tt.args.ctx, tt.args.collection, tt.args.featureID, false, p)
 			if err != nil {
 				if !tt.wantErr {
 					t.Errorf("GetFeature, error %v, wantErr %v", err, tt.wantErr)

--- a/internal/ogc/features/datasources/geopackage/geopackage_test.go
+++ b/internal/ogc/features/datasources/geopackage/geopackage_test.go
@@ -335,7 +335,7 @@ func TestGeoPackage_GetFeatures(t *testing.T) {
 			g.preparedStmtCache = NewCache()
 			url, _ := neturl.Parse("http://example.com")
 			p := domain.NewProfile(domain.RelAsLink, *url, []string{})
-			fc, cursor, err := g.GetFeatures(tt.args.ctx, tt.args.collection, tt.args.queryParams, false, p)
+			fc, cursor, err := g.GetFeatures(tt.args.ctx, tt.args.collection, tt.args.queryParams, domain.AxisOrderXY, p)
 			if err != nil {
 				if !tt.wantErr {
 					t.Errorf("GetFeatures, error %v, wantErr %v", err, tt.wantErr)
@@ -442,7 +442,7 @@ func TestGeoPackage_GetFeature(t *testing.T) {
 			}
 			url, _ := neturl.Parse("http://example.com")
 			p := domain.NewProfile(domain.RelAsLink, *url, []string{})
-			got, err := g.GetFeature(tt.args.ctx, tt.args.collection, tt.args.featureID, false, p)
+			got, err := g.GetFeature(tt.args.ctx, tt.args.collection, tt.args.featureID, domain.AxisOrderXY, p)
 			if err != nil {
 				if !tt.wantErr {
 					t.Errorf("GetFeature, error %v, wantErr %v", err, tt.wantErr)

--- a/internal/ogc/features/datasources/postgis/postgis.go
+++ b/internal/ogc/features/datasources/postgis/postgis.go
@@ -35,7 +35,7 @@ func (pg PostGIS) GetFeatures(_ context.Context, _ string, _ datasources.Feature
 	return nil, domain.Cursors{}, nil
 }
 
-func (pg PostGIS) GetFeature(__ context.Context, _ string, _ any, _ domain.AxisOrder, _ domain.Profile) (*domain.Feature, error) {
+func (pg PostGIS) GetFeature(_ context.Context, _ string, _ any, _ domain.AxisOrder, _ domain.Profile) (*domain.Feature, error) {
 	log.Println("PostGIS support is not implemented yet, this just serves to demonstrate that we can support multiple types of datasources")
 	return nil, nil
 }

--- a/internal/ogc/features/datasources/postgis/postgis.go
+++ b/internal/ogc/features/datasources/postgis/postgis.go
@@ -25,17 +25,17 @@ func (pg PostGIS) GetFeatureIDs(_ context.Context, _ string, _ datasources.Featu
 	return []int64{}, domain.Cursors{}, nil
 }
 
-func (pg PostGIS) GetFeaturesByID(_ context.Context, _ string, _ []int64, _ domain.Profile) (*domain.FeatureCollection, error) {
+func (pg PostGIS) GetFeaturesByID(_ context.Context, _ string, _ []int64, _ bool, _ domain.Profile) (*domain.FeatureCollection, error) {
 	log.Println("PostGIS support is not implemented yet, this just serves to demonstrate that we can support multiple types of datasources")
 	return &domain.FeatureCollection{}, nil
 }
 
-func (pg PostGIS) GetFeatures(_ context.Context, _ string, _ datasources.FeaturesCriteria, _ domain.Profile) (*domain.FeatureCollection, domain.Cursors, error) {
+func (pg PostGIS) GetFeatures(_ context.Context, _ string, _ datasources.FeaturesCriteria, _ bool, _ domain.Profile) (*domain.FeatureCollection, domain.Cursors, error) {
 	log.Println("PostGIS support is not implemented yet, this just serves to demonstrate that we can support multiple types of datasources")
 	return nil, domain.Cursors{}, nil
 }
 
-func (pg PostGIS) GetFeature(_ context.Context, _ string, _ any, _ domain.Profile) (*domain.Feature, error) {
+func (pg PostGIS) GetFeature(__ context.Context, _ string, _ any, _ bool, _ domain.Profile) (*domain.Feature, error) {
 	log.Println("PostGIS support is not implemented yet, this just serves to demonstrate that we can support multiple types of datasources")
 	return nil, nil
 }

--- a/internal/ogc/features/datasources/postgis/postgis.go
+++ b/internal/ogc/features/datasources/postgis/postgis.go
@@ -25,17 +25,17 @@ func (pg PostGIS) GetFeatureIDs(_ context.Context, _ string, _ datasources.Featu
 	return []int64{}, domain.Cursors{}, nil
 }
 
-func (pg PostGIS) GetFeaturesByID(_ context.Context, _ string, _ []int64, _ bool, _ domain.Profile) (*domain.FeatureCollection, error) {
+func (pg PostGIS) GetFeaturesByID(_ context.Context, _ string, _ []int64, _ domain.AxisOrder, _ domain.Profile) (*domain.FeatureCollection, error) {
 	log.Println("PostGIS support is not implemented yet, this just serves to demonstrate that we can support multiple types of datasources")
 	return &domain.FeatureCollection{}, nil
 }
 
-func (pg PostGIS) GetFeatures(_ context.Context, _ string, _ datasources.FeaturesCriteria, _ bool, _ domain.Profile) (*domain.FeatureCollection, domain.Cursors, error) {
+func (pg PostGIS) GetFeatures(_ context.Context, _ string, _ datasources.FeaturesCriteria, _ domain.AxisOrder, _ domain.Profile) (*domain.FeatureCollection, domain.Cursors, error) {
 	log.Println("PostGIS support is not implemented yet, this just serves to demonstrate that we can support multiple types of datasources")
 	return nil, domain.Cursors{}, nil
 }
 
-func (pg PostGIS) GetFeature(__ context.Context, _ string, _ any, _ bool, _ domain.Profile) (*domain.Feature, error) {
+func (pg PostGIS) GetFeature(__ context.Context, _ string, _ any, _ domain.AxisOrder, _ domain.Profile) (*domain.Feature, error) {
 	log.Println("PostGIS support is not implemented yet, this just serves to demonstrate that we can support multiple types of datasources")
 	return nil, nil
 }

--- a/internal/ogc/features/datasources/postgis/postgis_test.go
+++ b/internal/ogc/features/datasources/postgis/postgis_test.go
@@ -23,20 +23,20 @@ func TestPostGIS(t *testing.T) {
 	})
 
 	t.Run("GetFeaturesByID", func(t *testing.T) {
-		fc, err := pg.GetFeaturesByID(t.Context(), "", nil, p)
+		fc, err := pg.GetFeaturesByID(t.Context(), "", nil, false, p)
 		assert.NoError(t, err)
 		assert.NotNil(t, fc)
 	})
 
 	t.Run("GetFeatures", func(t *testing.T) {
-		fc, cursors, err := pg.GetFeatures(t.Context(), "", datasources.FeaturesCriteria{}, p)
+		fc, cursors, err := pg.GetFeatures(t.Context(), "", datasources.FeaturesCriteria{}, false, p)
 		assert.NoError(t, err)
 		assert.Nil(t, fc)
 		assert.NotNil(t, cursors)
 	})
 
 	t.Run("GetFeature", func(t *testing.T) {
-		f, err := pg.GetFeature(t.Context(), "", 0, p)
+		f, err := pg.GetFeature(t.Context(), "", 0, false, p)
 		assert.NoError(t, err)
 		assert.Nil(t, f)
 	})

--- a/internal/ogc/features/datasources/postgis/postgis_test.go
+++ b/internal/ogc/features/datasources/postgis/postgis_test.go
@@ -23,20 +23,20 @@ func TestPostGIS(t *testing.T) {
 	})
 
 	t.Run("GetFeaturesByID", func(t *testing.T) {
-		fc, err := pg.GetFeaturesByID(t.Context(), "", nil, false, p)
+		fc, err := pg.GetFeaturesByID(t.Context(), "", nil, domain.AxisOrderXY, p)
 		assert.NoError(t, err)
 		assert.NotNil(t, fc)
 	})
 
 	t.Run("GetFeatures", func(t *testing.T) {
-		fc, cursors, err := pg.GetFeatures(t.Context(), "", datasources.FeaturesCriteria{}, false, p)
+		fc, cursors, err := pg.GetFeatures(t.Context(), "", datasources.FeaturesCriteria{}, domain.AxisOrderXY, p)
 		assert.NoError(t, err)
 		assert.Nil(t, fc)
 		assert.NotNil(t, cursors)
 	})
 
 	t.Run("GetFeature", func(t *testing.T) {
-		f, err := pg.GetFeature(t.Context(), "", 0, false, p)
+		f, err := pg.GetFeature(t.Context(), "", 0, domain.AxisOrderXY, p)
 		assert.NoError(t, err)
 		assert.Nil(t, f)
 	})

--- a/internal/ogc/features/domain/schema.go
+++ b/internal/ogc/features/domain/schema.go
@@ -81,7 +81,8 @@ func NewSchema(fields []Field, fidColumn, externalFidColumn string) (*Schema, er
 	return &Schema{publicFields}, nil
 }
 
-// Schema derived from the data source (database) schema.
+// Schema derived from the data source schema.
+// Describes the schema of a single collection (table in the data source).
 type Schema struct {
 	Fields []Field
 }
@@ -141,7 +142,7 @@ func (f Field) ToTypeFormat() TypeFormat {
 	switch normalizedType {
 	case "boolean", "bool":
 		return TypeFormat{Type: "boolean"}
-	case "text", "char", "character", "character varying", "varchar", "nvarchar", "clob":
+	case "text", "char", "character", "charactervarying", "varchar", "nvarchar", "clob":
 		return TypeFormat{Type: "string"}
 	case "int", "integer", "tinyint", "smallint", "mediumint", "bigint", "int2", "int8":
 		return TypeFormat{Type: "integer"}

--- a/internal/ogc/features/domain/spatialref.go
+++ b/internal/ogc/features/domain/spatialref.go
@@ -7,11 +7,19 @@ import (
 )
 
 const (
-	CrsURIPrefix  = "http://www.opengis.net/def/crs/"
 	UndefinedSRID = 0
 	WGS84SRID     = 100000 // We use the SRID for CRS84 (WGS84) as defined in the GeoPackage, instead of EPSG:4326 (due to axis order). In time, we may need to read this value dynamically from the GeoPackage.
-	WGS84CodeOGC  = "CRS84"
-	WGS84CrsURI   = CrsURIPrefix + "OGC/1.3/" + WGS84CodeOGC
+
+	CrsURIPrefix = "http://www.opengis.net/def/crs/"
+	WGS84CodeOGC = "CRS84"
+	WGS84CrsURI  = CrsURIPrefix + "OGC/1.3/" + WGS84CodeOGC
+)
+
+type AxisOrder int
+
+const (
+	AxisOrderXY AxisOrder = iota
+	AxisOrderYX
 )
 
 // SRID Spatial Reference System Identifier: a unique value to unambiguously identify a spatial coordinate system.

--- a/internal/ogc/features/domain/spatialref.go
+++ b/internal/ogc/features/domain/spatialref.go
@@ -13,8 +13,10 @@ const (
 	CrsURIPrefix = "http://www.opengis.net/def/crs/"
 	WGS84CodeOGC = "CRS84"
 	WGS84CrsURI  = CrsURIPrefix + "OGC/1.3/" + WGS84CodeOGC
+	EPSGPrefix   = "EPSG:"
 )
 
+// AxisOrder the order of axis for a certain CRS
 type AxisOrder int
 
 const (
@@ -35,10 +37,9 @@ func (s SRID) GetOrDefault() int {
 }
 
 func EpsgToSrid(srs string) (SRID, error) {
-	prefix := "EPSG:"
-	srsCode, found := strings.CutPrefix(srs, prefix)
+	srsCode, found := strings.CutPrefix(srs, EPSGPrefix)
 	if !found {
-		return -1, fmt.Errorf("expected SRS to start with '%s', got %s", prefix, srs)
+		return -1, fmt.Errorf("expected SRS to start with '%s', got %s", EPSGPrefix, srs)
 	}
 	srid, err := strconv.Atoi(srsCode)
 	if err != nil {

--- a/internal/ogc/features/feature.go
+++ b/internal/ogc/features/feature.go
@@ -41,7 +41,7 @@ func (f *Features) Feature() http.HandlerFunc {
 		w.Header().Add(engine.HeaderContentCrs, contentCrs.ToLink())
 
 		datasource := f.datasources[datasourceKey{srid: outputSRID.GetOrDefault(), collectionID: collectionID}]
-		feat, err := datasource.GetFeature(r.Context(), collectionID, featureID, f.defaultProfile)
+		feat, err := datasource.GetFeature(r.Context(), collectionID, featureID, f.swapXY[outputSRID], f.defaultProfile)
 		if err != nil {
 			handleFeatureQueryError(w, collectionID, featureID, err)
 			return

--- a/internal/ogc/features/feature.go
+++ b/internal/ogc/features/feature.go
@@ -41,7 +41,7 @@ func (f *Features) Feature() http.HandlerFunc {
 		w.Header().Add(engine.HeaderContentCrs, contentCrs.ToLink())
 
 		datasource := f.datasources[datasourceKey{srid: outputSRID.GetOrDefault(), collectionID: collectionID}]
-		feat, err := datasource.GetFeature(r.Context(), collectionID, featureID, f.swapXY[outputSRID], f.defaultProfile)
+		feat, err := datasource.GetFeature(r.Context(), collectionID, featureID, f.axisOrderBySRID[outputSRID], f.defaultProfile)
 		if err != nil {
 			handleFeatureQueryError(w, collectionID, featureID, err)
 			return

--- a/internal/ogc/features/feature.go
+++ b/internal/ogc/features/feature.go
@@ -41,7 +41,7 @@ func (f *Features) Feature() http.HandlerFunc {
 		w.Header().Add(engine.HeaderContentCrs, contentCrs.ToLink())
 
 		datasource := f.datasources[datasourceKey{srid: outputSRID.GetOrDefault(), collectionID: collectionID}]
-		feat, err := datasource.GetFeature(r.Context(), collectionID, featureID, f.axisOrderBySRID[outputSRID], f.defaultProfile)
+		feat, err := datasource.GetFeature(r.Context(), collectionID, featureID, f.axisOrderBySRID[outputSRID.GetOrDefault()], f.defaultProfile)
 		if err != nil {
 			handleFeatureQueryError(w, collectionID, featureID, err)
 			return

--- a/internal/ogc/features/features.go
+++ b/internal/ogc/features/features.go
@@ -58,7 +58,7 @@ func (f *Features) Features() http.HandlerFunc {
 				TemporalCriteria: createTemporalCriteria(collection, referenceDate),
 				PropertyFilters:  propertyFilters,
 				// Add filter, filter-lang
-			}, f.defaultProfile)
+			}, f.swapXY[outputSRID], f.defaultProfile)
 			if err != nil {
 				handleFeaturesQueryError(w, collectionID, err)
 				return
@@ -78,8 +78,9 @@ func (f *Features) Features() http.HandlerFunc {
 				// Add filter, filter-lang
 			})
 			if err == nil && fids != nil {
+				// this is step 2: get the actual features in output CRS by feature ID
 				datasource = f.datasources[datasourceKey{srid: outputSRID.GetOrDefault(), collectionID: collectionID}]
-				fc, err = datasource.GetFeaturesByID(r.Context(), collectionID, fids, f.defaultProfile)
+				fc, err = datasource.GetFeaturesByID(r.Context(), collectionID, fids, f.swapXY[outputSRID], f.defaultProfile)
 			}
 			if err != nil {
 				handleFeaturesQueryError(w, collectionID, err)

--- a/internal/ogc/features/features.go
+++ b/internal/ogc/features/features.go
@@ -52,8 +52,8 @@ func (f *Features) Features() http.HandlerFunc {
 			fc, newCursor, err = datasource.GetFeatures(r.Context(), collectionID, ds.FeaturesCriteria{
 				Cursor:           encodedCursor.Decode(url.checksum()),
 				Limit:            limit,
-				InputSRID:        inputSRID.GetOrDefault(),
-				OutputSRID:       outputSRID.GetOrDefault(),
+				InputSRID:        inputSRID,
+				OutputSRID:       outputSRID,
 				Bbox:             bbox,
 				TemporalCriteria: createTemporalCriteria(collection, referenceDate),
 				PropertyFilters:  propertyFilters,
@@ -70,8 +70,8 @@ func (f *Features) Features() http.HandlerFunc {
 			fids, newCursor, err = datasource.GetFeatureIDs(r.Context(), collectionID, ds.FeaturesCriteria{
 				Cursor:           encodedCursor.Decode(url.checksum()),
 				Limit:            limit,
-				InputSRID:        inputSRID.GetOrDefault(),
-				OutputSRID:       outputSRID.GetOrDefault(),
+				InputSRID:        inputSRID,
+				OutputSRID:       outputSRID,
 				Bbox:             bbox,
 				TemporalCriteria: createTemporalCriteria(collection, referenceDate),
 				PropertyFilters:  propertyFilters,

--- a/internal/ogc/features/features.go
+++ b/internal/ogc/features/features.go
@@ -58,7 +58,7 @@ func (f *Features) Features() http.HandlerFunc {
 				TemporalCriteria: createTemporalCriteria(collection, referenceDate),
 				PropertyFilters:  propertyFilters,
 				// Add filter, filter-lang
-			}, f.swapXY[outputSRID], f.defaultProfile)
+			}, f.axisOrderBySRID[outputSRID], f.defaultProfile)
 			if err != nil {
 				handleFeaturesQueryError(w, collectionID, err)
 				return
@@ -80,7 +80,7 @@ func (f *Features) Features() http.HandlerFunc {
 			if err == nil && fids != nil {
 				// this is step 2: get the actual features in output CRS by feature ID
 				datasource = f.datasources[datasourceKey{srid: outputSRID.GetOrDefault(), collectionID: collectionID}]
-				fc, err = datasource.GetFeaturesByID(r.Context(), collectionID, fids, f.swapXY[outputSRID], f.defaultProfile)
+				fc, err = datasource.GetFeaturesByID(r.Context(), collectionID, fids, f.axisOrderBySRID[outputSRID], f.defaultProfile)
 			}
 			if err != nil {
 				handleFeaturesQueryError(w, collectionID, err)

--- a/internal/ogc/features/features.go
+++ b/internal/ogc/features/features.go
@@ -58,7 +58,7 @@ func (f *Features) Features() http.HandlerFunc {
 				TemporalCriteria: createTemporalCriteria(collection, referenceDate),
 				PropertyFilters:  propertyFilters,
 				// Add filter, filter-lang
-			}, f.axisOrderBySRID[outputSRID], f.defaultProfile)
+			}, f.axisOrderBySRID[outputSRID.GetOrDefault()], f.defaultProfile)
 			if err != nil {
 				handleFeaturesQueryError(w, collectionID, err)
 				return
@@ -80,7 +80,7 @@ func (f *Features) Features() http.HandlerFunc {
 			if err == nil && fids != nil {
 				// this is step 2: get the actual features in output CRS by feature ID
 				datasource = f.datasources[datasourceKey{srid: outputSRID.GetOrDefault(), collectionID: collectionID}]
-				fc, err = datasource.GetFeaturesByID(r.Context(), collectionID, fids, f.axisOrderBySRID[outputSRID], f.defaultProfile)
+				fc, err = datasource.GetFeaturesByID(r.Context(), collectionID, fids, f.axisOrderBySRID[outputSRID.GetOrDefault()], f.defaultProfile)
 			}
 			if err != nil {
 				handleFeaturesQueryError(w, collectionID, err)

--- a/internal/ogc/features/main.go
+++ b/internal/ogc/features/main.go
@@ -111,6 +111,7 @@ func determineAxisOrder(datasources map[datasourceKey]ds.Datasource) map[int]dom
 	if true {
 		return map[int]domain.AxisOrder{}
 	}
+	log.Println("start determining axis order for all configured CRS's")
 	order := map[int]domain.AxisOrder{
 		domain.WGS84SRID: domain.AxisOrderXY, // We know CRS84 is XY, see https://spatialreference.org/ref/ogc/CRS84/
 	}
@@ -124,6 +125,7 @@ func determineAxisOrder(datasources map[datasourceKey]ds.Datasource) map[int]dom
 			order[key.srid] = axisOrder
 		}
 	}
+	log.Println("done determining axis order for all configured CRS's")
 	return order
 }
 

--- a/internal/ogc/features/main.go
+++ b/internal/ogc/features/main.go
@@ -107,24 +107,25 @@ func createDatasources(e *engine.Engine) map[datasourceKey]ds.Datasource {
 }
 
 func determineAxisOrder(datasources map[datasourceKey]ds.Datasource) map[domain.SRID]domain.AxisOrder {
-	swapXY := map[domain.SRID]domain.AxisOrder{
+	order := map[domain.SRID]domain.AxisOrder{
 		domain.WGS84SRID: domain.AxisOrderXY, // We know CRS84 is XY, see https://spatialreference.org/ref/ogc/CRS84/
 	}
 	for key := range datasources {
 		datasourceSRID := domain.SRID(key.srid)
-		if _, ok := swapXY[datasourceSRID]; !ok {
-			swap, err := ShouldSwapXY(datasourceSRID)
+		if _, ok := order[datasourceSRID]; !ok {
+			swapXY, err := ShouldSwapXY(datasourceSRID)
 			if err != nil {
 				log.Printf("Warning: failed to determine whether EPSG:%d needs "+
 					"swap of X/Y axis: %v. Defaulting to XY order.", datasourceSRID, err)
 			}
-			if swap {
-				swapXY[datasourceSRID] = domain.AxisOrderYX
+			if swapXY {
+				order[datasourceSRID] = domain.AxisOrderYX
+			} else {
+				order[datasourceSRID] = domain.AxisOrderXY
 			}
-			swapXY[datasourceSRID] = domain.AxisOrderXY
 		}
 	}
-	return swapXY
+	return order
 }
 
 func cacheConfiguredFeatureCollections(e *engine.Engine) map[string]config.GeoSpatialCollection {

--- a/internal/ogc/features/main.go
+++ b/internal/ogc/features/main.go
@@ -112,16 +112,12 @@ func determineAxisOrder(datasources map[datasourceKey]ds.Datasource) map[int]dom
 	}
 	for key := range datasources {
 		if _, ok := order[key.srid]; !ok {
-			swapXY, err := ShouldSwapXY(domain.SRID(key.srid))
+			axisOrder, err := GetAxisOrder(domain.SRID(key.srid))
 			if err != nil {
 				log.Printf("Warning: failed to determine whether EPSG:%d needs "+
 					"swap of X/Y axis: %v. Defaulting to XY order.", key.srid, err)
 			}
-			if swapXY {
-				order[key.srid] = domain.AxisOrderYX
-			} else {
-				order[key.srid] = domain.AxisOrderXY
-			}
+			order[key.srid] = axisOrder
 		}
 	}
 	return order

--- a/internal/ogc/features/main.go
+++ b/internal/ogc/features/main.go
@@ -113,13 +113,13 @@ func createSwapXY(datasources map[datasourceKey]ds.Datasource) map[domain.SRID]b
 	for key := range datasources {
 		datasourceSRID := domain.SRID(key.srid)
 		if _, ok := swapXY[datasourceSRID]; !ok {
-			shouldSwap, err := ShouldSwapXY(datasourceSRID)
+			swap, err := ShouldSwapXY(datasourceSRID)
 			if err != nil {
 				log.Printf("Warning: failed to determine if EPSG:%d needs "+
 					"swap of X/Y axis: %v. Defaulting to XY order.", datasourceSRID, err)
-				shouldSwap = false
+				swap = false
 			}
-			swapXY[datasourceSRID] = shouldSwap
+			swapXY[datasourceSRID] = swap
 		}
 	}
 	return swapXY

--- a/internal/ogc/features/main.go
+++ b/internal/ogc/features/main.go
@@ -107,6 +107,10 @@ func createDatasources(e *engine.Engine) map[datasourceKey]ds.Datasource {
 }
 
 func determineAxisOrder(datasources map[datasourceKey]ds.Datasource) map[int]domain.AxisOrder {
+	// TODO: disable swapping x/y axis until https://github.com/PDOK/gokoala/pull/312 is resolved.
+	if true {
+		return map[int]domain.AxisOrder{}
+	}
 	order := map[int]domain.AxisOrder{
 		domain.WGS84SRID: domain.AxisOrderXY, // We know CRS84 is XY, see https://spatialreference.org/ref/ogc/CRS84/
 	}

--- a/internal/ogc/features/proj.go
+++ b/internal/ogc/features/proj.go
@@ -11,6 +11,11 @@ import (
 
 const projInfoTool = "projinfo"
 
+var (
+	execCommand  = exec.Command  // Allow mocking
+	execLookPath = exec.LookPath // Allow mocking
+)
+
 // ProjInfo output in PROJJSON format. Note: only relevant fields are mapped in this struct.
 type ProjInfo struct {
 	CoordinateSystem CoordinateSystem `json:"coordinate_system"` //nolint:tagliatelle
@@ -41,13 +46,13 @@ func ShouldSwapXY(srid domain.SRID) (bool, error) {
 }
 
 func execProjInfo(epsgCode string) (*ProjInfo, error) {
-	_, err := exec.LookPath(projInfoTool)
+	_, err := execLookPath(projInfoTool)
 	if err != nil {
 		return nil, fmt.Errorf("%s command not found in PATH: %w", projInfoTool, err)
 	}
 
 	// Run 'projinfo' and return output in PROJJSON format (https://proj.org/en/stable/specifications/projjson.html)
-	cmd := exec.Command(projInfoTool, epsgCode, "-o", "projjson", "--single-line", "-q")
+	cmd := execCommand(projInfoTool, epsgCode, "-o", "projjson", "--single-line", "-q")
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute %s command: %w", projInfoTool, err)

--- a/internal/ogc/features/proj.go
+++ b/internal/ogc/features/proj.go
@@ -30,7 +30,7 @@ type ProjInfo struct {
 
 // GetAxisOrder return XY or YX axis order for the given SRID
 func GetAxisOrder(srid domain.SRID) (domain.AxisOrder, error) {
-	epsgCode := fmt.Sprintf("%s:%d", domain.EPSGPrefix, srid)
+	epsgCode := fmt.Sprintf("%s%d", domain.EPSGPrefix, srid)
 	info, err := execProjInfo(epsgCode)
 	if err != nil {
 		return -1, err

--- a/internal/ogc/features/proj.go
+++ b/internal/ogc/features/proj.go
@@ -26,7 +26,7 @@ type CoordinateSystem struct {
 	Axis []Axis `json:"axis"`
 }
 
-// Axis represents a CRS axis
+// Axis represents an X or Y axis
 type Axis struct {
 	Name         string `json:"name"`
 	Abbreviation string `json:"abbreviation"`

--- a/internal/ogc/features/proj.go
+++ b/internal/ogc/features/proj.go
@@ -1,0 +1,64 @@
+package features
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/PDOK/gokoala/internal/ogc/features/domain"
+)
+
+const projInfoTool = "projinfo"
+
+// ProjInfo output in PROJJSON format. Note: only relevant fields are mapped in this struct.
+type ProjInfo struct {
+	CoordinateSystem CoordinateSystem `json:"coordinate_system"` //nolint:tagliatelle
+}
+
+// CoordinateSystem represents the CRS definition
+type CoordinateSystem struct {
+	Axis []Axis `json:"axis"`
+}
+
+// Axis represents a CRS axis
+type Axis struct {
+	Name         string `json:"name"`
+	Abbreviation string `json:"abbreviation"`
+	Direction    string `json:"direction"`
+	Unit         string `json:"unit"`
+}
+
+// ShouldSwapXY true when given SRID should be YX, false when SRID should be XY.
+func ShouldSwapXY(srid domain.SRID) (bool, error) {
+	epsgCode := fmt.Sprintf("EPSG:%d", srid)
+	info, err := execProjInfo(epsgCode)
+	if err != nil {
+		return false, err
+	}
+	// east/north == XY, north/east == YX.
+	return info.CoordinateSystem.Axis[0].Direction == "north", nil
+}
+
+func execProjInfo(epsgCode string) (*ProjInfo, error) {
+	_, err := exec.LookPath(projInfoTool)
+	if err != nil {
+		return nil, fmt.Errorf("%s command not found in PATH: %w", projInfoTool, err)
+	}
+
+	// Run 'projinfo' and return output in PROJJSON format (https://proj.org/en/stable/specifications/projjson.html)
+	cmd := exec.Command(projInfoTool, epsgCode, "-o", "projjson", "--single-line", "-q")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute %s command: %w", projInfoTool, err)
+	}
+
+	var projInfo ProjInfo
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(output))), &projInfo); err != nil {
+		return nil, fmt.Errorf("failed to parse %s output: %w", projInfoTool, err)
+	}
+	if len(projInfo.CoordinateSystem.Axis) < 1 {
+		return nil, fmt.Errorf("invalid %s output: axis not found", projInfoTool)
+	}
+	return &projInfo, nil
+}

--- a/internal/ogc/features/proj_test.go
+++ b/internal/ogc/features/proj_test.go
@@ -1,0 +1,140 @@
+package features
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+
+	"github.com/PDOK/gokoala/internal/ogc/features/domain" // SRID is used
+	"github.com/stretchr/testify/assert"
+)
+
+// Helps to mock exec.Command. Inspired by https://www.joeshaw.org/testing-with-os-exec-and-testmain/
+func TestHelperProcess(*testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprint(os.Stdout, os.Getenv("STDOUT"))
+	i, _ := strconv.Atoi(os.Getenv("EXIT_CODE"))
+	os.Exit(i)
+}
+
+func TestShouldSwapXY(t *testing.T) {
+	// Save original functions and restore them after all tests in this function are done
+	originalCmdFunc := execCommand
+	originalLookPathFunc := execLookPath
+	defer func() {
+		execCommand = originalCmdFunc
+		execLookPath = originalLookPathFunc
+	}()
+
+	type args struct {
+		name            string
+		srid            domain.SRID
+		mockLookPathErr error
+		mockCmdOutput   string
+		mockCmdExitCode int
+		expectedSwap    bool
+		expectedError   bool
+		expectedErrMsg  string
+	}
+	tests := []args{
+		{
+			name:            "should swap - first axis direction is east",
+			srid:            domain.SRID(28992),
+			mockCmdOutput:   `{"coordinate_system":{"axis":[{"direction":"east"}, {"direction":"north"}]}}`,
+			mockCmdExitCode: 0,
+			expectedSwap:    false,
+			expectedError:   false,
+		},
+		{
+			name:            "should not swap - first axis direction is north",
+			srid:            domain.SRID(4258),
+			mockCmdOutput:   `{"coordinate_system":{"axis":[{"direction":"north"}, {"direction":"east"}]}}`,
+			mockCmdExitCode: 0,
+			expectedSwap:    true,
+			expectedError:   false,
+		},
+		{
+			name:            "error - projinfo not found (LookPath fails)",
+			srid:            domain.SRID(1000),
+			mockLookPathErr: errors.New("simulated LookPath error: command not found"),
+			expectedError:   true,
+			expectedErrMsg:  "projinfo command not found in PATH",
+		},
+		{
+			name:            "error - projinfo command execution fails (non-zero exit)",
+			srid:            domain.SRID(2000),
+			mockCmdOutput:   "error from command",
+			mockCmdExitCode: 1, // Simulate command failure
+			expectedError:   true,
+			expectedErrMsg:  "failed to execute projinfo command",
+		},
+		{
+			name:            "error - projinfo output is invalid JSON",
+			srid:            domain.SRID(3000),
+			mockCmdOutput:   "this is not valid json",
+			mockCmdExitCode: 0,
+			expectedError:   true,
+			expectedErrMsg:  "failed to parse projinfo output",
+		},
+		{
+			name:            "error - projinfo output JSON lacks axis",
+			srid:            domain.SRID(4000),
+			mockCmdOutput:   `{"coordinate_system":{}}`,
+			mockCmdExitCode: 0,
+			expectedError:   true,
+			expectedErrMsg:  "invalid projinfo output: axis not found",
+		},
+		{
+			name:            "error - projinfo output JSON has empty axis",
+			srid:            domain.SRID(5000),
+			mockCmdOutput:   `{"coordinate_system":{"axis":[]}}`,
+			mockCmdExitCode: 0,
+			expectedError:   true,
+			expectedErrMsg:  "invalid projinfo output: axis not found",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup mocks for execLookPath and execCommand for this specific test case
+			execLookPath = func(file string) (string, error) {
+				if file == projInfoTool {
+					if tc.mockLookPathErr != nil {
+						return "", tc.mockLookPathErr
+					}
+					return "/test/projinfo", nil
+				}
+				return originalLookPathFunc(file)
+			}
+
+			execCommand = func(name string, arg ...string) *exec.Cmd {
+				// Check if the command is the one we intend to mock by name.
+				// It could be "projinfo" or the dummy path "/test/projinfo".
+				if name == projInfoTool || name == "/test/projinfo" {
+					cs := []string{"-test.run=TestHelperProcess", "--", name}
+					cmd := exec.Command(os.Args[0], cs...) //nolint:gosec    // Use test binary itself
+					cmd.Env = []string{
+						"GO_WANT_HELPER_PROCESS=1",
+						"STDOUT=" + tc.mockCmdOutput,
+						"EXIT_CODE=" + strconv.Itoa(tc.mockCmdExitCode),
+					}
+					return cmd
+				}
+				return originalCmdFunc(name, arg...)
+			}
+
+			swap, err := ShouldSwapXY(tc.srid)
+
+			if tc.expectedError {
+				assert.Contains(t, err.Error(), tc.expectedErrMsg, "Test: %s. Error message mismatch for SRID %d", tc.name, tc.srid)
+			} else {
+				assert.Equal(t, tc.expectedSwap, swap, "Test: %s. Swap value mismatch for SRID %d", tc.name, tc.srid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Swap XY to YX when a certain CRS for a configured datasource (eg. geopackage) requires this. Uses `proj` to determine axis order. For example relevant when serving features in EPSG:4258.

## Type of change

- Improvement of existing feature
- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR