### PR TITLE
fix: check if configured external feature ID is present on startup

### DIFF
--- a/internal/ogc/features/domain/relation.go
+++ b/internal/ogc/features/domain/relation.go
@@ -30,8 +30,8 @@ func NewFeatureRelation(name, externalFidColumn string, collectionNames []string
 // newFeatureRelationName derive name of the feature relation.
 //
 // In the datasource we have fields named 'foobar_external_fid' or 'foobar_sometext_external_fid' containing UUID's to
-// features in the 'foobar' collection. The feature relation field name will be 'foobar' or 'foobar_sometext'. This is
-// the name of expose in the feature data (GeoJSON) and the schema (JSON-Schema).
+// features in the 'foobar' collection. The field containing this relation will be named 'foobar' or 'foobar_sometext'.
+// This name will appear in the feature data (GeoJSON) and the schema (JSON-Schema) to represent the feature relation.
 func newFeatureRelationName(name string, externalFidColumn string) string {
 	regex, _ := regexp.Compile(regexRemoveSeparators + externalFidColumn + regexRemoveSeparators)
 	return regex.ReplaceAllString(name, "")

--- a/internal/ogc/features/domain/schema.go
+++ b/internal/ogc/features/domain/schema.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"slices"
 	"strings"
@@ -84,7 +85,18 @@ func NewSchema(fields []Field, fidColumn, externalFidColumn string) (*Schema, er
 
 		publicFields = append(publicFields, field)
 	}
-	return &Schema{publicFields}, nil
+
+	schema := &Schema{publicFields}
+	if externalFidColumn != "" && !schema.HasExternalFid() {
+		return nil, fmt.Errorf("external feature ID column '%s' configured but not found in schema", externalFidColumn)
+	}
+	return schema, nil
+}
+
+// IsDate convenience function to check if the given field is a Date
+func (s Schema) IsDate(field string) bool {
+	f := s.findField(field)
+	return f.ToTypeFormat().Format == formatDateOnly
 }
 
 // HasExternalFid convenience function to check if this schema defines an external feature ID
@@ -95,12 +107,6 @@ func (s Schema) HasExternalFid() bool {
 		}
 	}
 	return false
-}
-
-// IsDate convenience function to check if the given field is a Date
-func (s Schema) IsDate(field string) bool {
-	f := s.findField(field)
-	return f.ToTypeFormat().Format == formatDateOnly
 }
 
 func (s Schema) findField(name string) Field {

--- a/internal/ogc/features/domain/schema_test.go
+++ b/internal/ogc/features/domain/schema_test.go
@@ -71,6 +71,17 @@ func TestNewSchema(t *testing.T) {
 			expectedErrMsg: "empty field type found, field type is required",
 		},
 		{
+			name: "fail on non-existing external fid",
+			fields: []Field{
+				{Name: "id", Type: "integer"},
+				{Name: "location", Type: "Point"},
+			},
+			fidColumn:      "id",
+			externalFid:    "ext_fid", // not present
+			expectedError:  true,
+			expectedErrMsg: "external feature ID column 'ext_fid' configured but not found in schema",
+		},
+		{
 			name: "fields to skip are ignored",
 			fields: []Field{
 				{Name: "id", Type: "integer"},


### PR DESCRIPTION
# Description

check if configured external feature ID is present on startup

## Type of change

- Improvement of existing feature

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR