### PR TITLE
fix: read schema only on feature tables that belong to collections

### DIFF
--- a/internal/ogc/features/domain/mapper.go
+++ b/internal/ogc/features/domain/mapper.go
@@ -71,7 +71,8 @@ func MapRowsToFeatures(ctx context.Context, rows *sqlx.Rows, fidColumn string, e
 			return result, nil, err
 		}
 		feature := &Feature{Properties: NewFeatureProperties(propertiesOrder)}
-		np, err := mapColumnsToFeature(ctx, firstRow, feature, columns, values, fidColumn, externalFidColumn, geomColumn, schema, mapGeom, mapRel)
+		np, err := mapColumnsToFeature(ctx, firstRow, feature, columns, values, fidColumn,
+			externalFidColumn, geomColumn, schema, mapGeom, mapRel)
 		if err != nil {
 			return result, nil, err
 		} else if firstRow {


### PR DESCRIPTION
# Description

fix: read schema only on feature tables that belong to collections. Ignore tables that aren't configured as a collection (but do log these)

## Type of change

- Bugfix

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR