### PR TITLE
fix: column ordering, and fix overwrite of geom swapcoords by "select *"

### DIFF
--- a/internal/ogc/features/features_test.go
+++ b/internal/ogc/features/features_test.go
@@ -629,7 +629,7 @@ func TestFeatures(t *testing.T) {
 			},
 		},
 		{
-			name: "Request features where properties are in a specific order",
+			name: "Request features where properties are in a specific order (note: JSON allows out-of-order properties)",
 			fields: fields{
 				configFile:   "internal/ogc/features/testdata/config_features_properties_order.yaml",
 				url:          "http://localhost:8080/collections/:collectionId/items?f=json",
@@ -639,6 +639,20 @@ func TestFeatures(t *testing.T) {
 			},
 			want: want{
 				body:       "internal/ogc/features/testdata/expected_features_properties_order.json",
+				statusCode: http.StatusOK,
+			},
+		},
+		{
+			name: "Request features where properties are in a specific order as HTML (to valide strict ordering)",
+			fields: fields{
+				configFile:   "internal/ogc/features/testdata/config_features_properties_order.yaml",
+				url:          "http://localhost:8080/collections/:collectionId/items?f=html",
+				collectionID: "dutch-addresses",
+				contentCrs:   "<" + domain.WGS84CrsURI + ">",
+				format:       "html",
+			},
+			want: want{
+				body:       "internal/ogc/features/testdata/expected_features_properties_order.html",
 				statusCode: http.StatusOK,
 			},
 		},

--- a/internal/ogc/features/testdata/expected_features_properties_order.html
+++ b/internal/ogc/features/testdata/expected_features_properties_order.html
@@ -1,0 +1,200 @@
+<tr>
+  <td class="w-25">building</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">alternativeidentifier</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">beginlifespanversion</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">endlifespanversion</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">validfrom</td>
+
+  <td>2009-12-21T00:00:00Z</td>
+</tr>
+<tr>
+  <td class="w-25">component_adminunitname_6</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">component_adminunitname_4</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">component_adminunitname_5</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">component_adminunitname_2</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">component_adminunitname_3</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">component_adminunitname_1</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">validto</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">component_thoroughfarename</td>
+
+  <td>Achtertune</td>
+</tr>
+<tr>
+  <td class="w-25">component_postaldescriptor</td>
+
+  <td>1794BL</td>
+</tr>
+<tr>
+  <td class="w-25">component_addressareaname</td>
+
+  <td>Oosterend</td>
+</tr>
+<tr>
+  <td class="w-25">locator_designator_addressnumber</td>
+
+  <td>5</td>
+</tr>
+<tr>
+  <td class="w-25">locator_designator_addressnumberextension</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">locator_designator_addressnumber2ndextension</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">locator_level</td>
+
+  <td>unit level</td>
+</tr>
+<tr>
+  <td class="w-25">locator_href</td>
+
+  <td>http://inspire.ec.europa.eu/codelist/LocatorLevelValue/unitLevel</td>
+</tr>
+<tr>
+  <td class="w-25">locator_designator_buildingidentifier</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">locator_designator_buildingidentifierprefix</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">locator_designator_corneraddress1stidentifier</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">locator_designator_corneraddress2ndidentifier</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">locator_designator_entrancedooridentifier</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">locator_designator_flooridentifier</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">locator_designator_kilometrepoint</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">locator_designator_postaldeliveryidentifier</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">locator_designator_staircaseidentifier</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">locator_designator_unitidentifier</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">locator_name</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">parcel</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">parentaddress</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">position_specification</td>
+
+  <td>entrance</td>
+</tr>
+<tr>
+  <td class="w-25">position_specification_href</td>
+
+  <td>http://inspire.ec.europa.eu/codelist/GeometrySpecificationValue/entrance</td>
+</tr>
+<tr>
+  <td class="w-25">position_method</td>
+
+  <td>by administrator</td>
+</tr>
+<tr>
+  <td class="w-25">position_method_href</td>
+
+  <td>http://inspire.ec.europa.eu/codelist/GeometryMethodValue/byAdministrator</td>
+</tr>
+<tr>
+  <td class="w-25">position_default</td>
+
+  <td>true</td>
+</tr>
+<tr>
+  <td class="w-25">status</td>
+
+  <td></td>
+</tr>
+<tr>
+  <td class="w-25">status_href</td>
+
+  <td></td>
+</tr>


### PR DESCRIPTION
# Description

https://github.com/PDOK/gokoala/pull/322 didn't work as expected when `properties` and `propertiesExcludeUnknown` was in use. This PR fixes that.

## Type of change

- Bugfix

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR