### PR TITLE
chore: preventive patch for eslint-config-prettier

### DIFF
--- a/viewer/package-lock.json
+++ b/viewer/package-lock.json
@@ -42,7 +42,7 @@
         "cypress-vite": "^1.5.0",
         "esbuild-visualizer": "^0.6.0",
         "eslint": "8.57.0",
-        "eslint-config-prettier": "9.1.0",
+        "eslint-config-prettier": "9.1.2",
         "eslint-plugin-prettier": "5.1.3",
         "prettier": "3.3.1",
         "prettier-eslint": "16.3.0",
@@ -8145,9 +8145,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
-      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
+      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -51,7 +51,7 @@
     "cypress-vite": "^1.5.0",
     "esbuild-visualizer": "^0.6.0",
     "eslint": "8.57.0",
-    "eslint-config-prettier": "9.1.0",
+    "eslint-config-prettier": "9.1.2",
     "eslint-plugin-prettier": "5.1.3",
     "prettier": "3.3.1",
     "prettier-eslint": "16.3.0",


### PR DESCRIPTION
# Description

## Type of change

- Security patch for CVE-2025-54313. GoKoala is not affected, just to make sure.

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR