### PR TITLE
perf: run tests within the ogc/features package in parallel

### DIFF
--- a/internal/ogc/features/feature_test.go
+++ b/internal/ogc/features/feature_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestFeature(t *testing.T) {
+	t.Parallel()
+
 	type fields struct {
 		configFiles  []string
 		url          string

--- a/internal/ogc/features/feature_test.go
+++ b/internal/ogc/features/feature_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/PDOK/gokoala/internal/engine"
 	"github.com/stretchr/testify/assert"
@@ -347,6 +346,8 @@ func TestFeature(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			for _, configFile := range tt.fields.configFiles {
 				dir := filepath.Dir(configFile)
 				datasourceName := filepath.Base(dir)
@@ -354,9 +355,7 @@ func TestFeature(t *testing.T) {
 				// nested subtest for each config-file/datasource
 				// tip: in JetBrains IDEs you can still jump to failed tests by explicitly selecting "jump to source"
 				t.Run(datasourceName, func(t *testing.T) {
-					// mock time
-					now = func() time.Time { return time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC) }
-					engine.Now = now
+					t.Parallel()
 
 					req, err := createRequest(tt.fields.url, tt.fields.collectionID, tt.fields.featureID, tt.fields.format)
 					assert.NoError(t, err)

--- a/internal/ogc/features/features_test.go
+++ b/internal/ogc/features/features_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/PDOK/gokoala/internal/engine"
 	"github.com/PDOK/gokoala/internal/ogc/features/domain"
@@ -871,6 +870,8 @@ func TestFeatures(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			for _, configFile := range tt.fields.configFiles {
 				dir := filepath.Dir(configFile)
 				datasourceName := filepath.Base(dir)
@@ -878,9 +879,7 @@ func TestFeatures(t *testing.T) {
 				// nested subtest for each config-file/datasource
 				// tip: in JetBrains IDEs you can still jump to failed tests by explicitly selecting "jump to source"
 				t.Run(datasourceName, func(t *testing.T) {
-					// mock time
-					now = func() time.Time { return time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC) }
-					engine.Now = now
+					t.Parallel()
 
 					req, err := createRequest(tt.fields.url, tt.fields.collectionID, "", tt.fields.format)
 					assert.NoError(t, err)

--- a/internal/ogc/features/features_test.go
+++ b/internal/ogc/features/features_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestFeatures(t *testing.T) {
+	t.Parallel()
+
 	type fields struct {
 		configFiles  []string
 		url          string

--- a/internal/ogc/features/schema_test.go
+++ b/internal/ogc/features/schema_test.go
@@ -218,6 +218,8 @@ func TestSchema(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			for _, configFile := range tt.fields.configFiles {
 				dir := filepath.Dir(configFile)
 				datasourceName := filepath.Base(dir)
@@ -225,6 +227,8 @@ func TestSchema(t *testing.T) {
 				// nested subtest for each config-file/datasource
 				// tip: in JetBrains IDEs you can still jump to failed tests by explicitly selecting "jump to source"
 				t.Run(datasourceName, func(t *testing.T) {
+					t.Parallel()
+
 					req, err := createRequest(tt.fields.url, tt.fields.collectionID, "", tt.fields.format)
 					assert.NoError(t, err)
 					rr, ts := createMockServer()

--- a/internal/ogc/features/schema_test.go
+++ b/internal/ogc/features/schema_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestSchema(t *testing.T) {
+	t.Parallel()
+
 	type fields struct {
 		configFiles  []string
 		url          string

--- a/internal/ogc/features/setup_test.go
+++ b/internal/ogc/features/setup_test.go
@@ -45,6 +45,10 @@ func TestMain(m *testing.M) {
 }
 
 func setup(ctx context.Context) *compose.DockerCompose {
+	// mock time
+	now = func() time.Time { return time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC) }
+	engine.Now = now
+
 	port, stack, err := setupPostgres(ctx)
 	if err != nil {
 		log.Fatal("failed to start docker compose", err)


### PR DESCRIPTION
# Description

In Go, tests in different packages run in parallel automatically. This enabled parallel tests WITHIN the features package since this package contains a lot of tests.

## Type of change

- Test performance improvement

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR