### PR TITLE
fix: also format date/time as UTC in HTML when viewing a single feature.

### DIFF
--- a/internal/ogc/features/feature_test.go
+++ b/internal/ogc/features/feature_test.go
@@ -166,6 +166,23 @@ func TestFeature(t *testing.T) {
 			},
 		},
 		{
+			name: "Request HTML for address feature 25",
+			fields: fields{
+				configFiles: []string{
+					"internal/ogc/features/testdata/geopackage/config_features_multiple_gpkgs.yaml",
+					"internal/ogc/features/testdata/postgresql/config_features_multiple_projections.yaml",
+				},
+				url:          "http://localhost:8080/collections/:collectionId/items/:featureId",
+				collectionID: "dutch-addresses",
+				featureID:    "122d22de-fe71-5f55-b0a4-df4534f43ff1",
+				format:       "html",
+			},
+			want: want{
+				body:       "internal/ogc/features/testdata/expected_feature_25.html",
+				statusCode: http.StatusOK,
+			},
+		},
+		{
 			name: "Request output in WGS84 explicitly",
 			fields: fields{
 				configFiles: []string{

--- a/internal/ogc/features/templates/feature.go.html
+++ b/internal/ogc/features/templates/feature.go.html
@@ -55,7 +55,7 @@
 
                     {{ $value := $.Params.Properties.Value $key }}
                     {{- if isdate $value -}}
-                    <td>{{ $value | date "2006/01/02 15:04:05" }}</td>
+                    <td>{{ dateInZone "2006-01-02T15:04:05Z" $value "UTC" }}</td>
 
                     {{- else if hasSuffix ".href" $key -}}
                     {{- /* render links for relations between features (OGC API part 5) */ -}}

--- a/internal/ogc/features/testdata/expected_feature_25.html
+++ b/internal/ogc/features/testdata/expected_feature_25.html
@@ -1,0 +1,136 @@
+<table class="table table-striped">
+    <thead>
+    <tr>
+        <th colspan="2" scope="row">122d22de-fe71-5f55-b0a4-df4534f43ff1</th>
+    </tr>
+    </thead>
+    <tbody>
+
+
+
+
+    <tr>
+        <td class="w-25">alternativeidentifier</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">beginlifespanversion</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">building</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">component_addressareaname</td>
+
+        <td>Den Burg</td></tr><tr>
+        <td class="w-25">component_adminunitname_1</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">component_adminunitname_2</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">component_adminunitname_3</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">component_adminunitname_4</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">component_adminunitname_5</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">component_adminunitname_6</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">component_postaldescriptor</td>
+
+        <td>1791DG</td></tr><tr>
+        <td class="w-25">component_thoroughfarename</td>
+
+        <td>Ada van Hollandstraat</td></tr><tr>
+        <td class="w-25">endlifespanversion</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">locator_designator_addressnumber</td>
+
+        <td>7</td></tr><tr>
+        <td class="w-25">locator_designator_addressnumber2ndextension</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">locator_designator_addressnumberextension</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">locator_designator_buildingidentifier</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">locator_designator_buildingidentifierprefix</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">locator_designator_corneraddress1stidentifier</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">locator_designator_corneraddress2ndidentifier</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">locator_designator_entrancedooridentifier</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">locator_designator_flooridentifier</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">locator_designator_kilometrepoint</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">locator_designator_postaldeliveryidentifier</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">locator_designator_staircaseidentifier</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">locator_designator_unitidentifier</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">locator_href</td>
+
+        <td>http://inspire.ec.europa.eu/codelist/LocatorLevelValue/unitLevel</td></tr><tr>
+        <td class="w-25">locator_level</td>
+
+        <td>unit level</td></tr><tr>
+        <td class="w-25">locator_name</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">parcel</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">parentaddress</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">position_default</td>
+
+        <td>true</td></tr><tr>
+        <td class="w-25">position_method</td>
+
+        <td>by administrator</td></tr><tr>
+        <td class="w-25">position_method_href</td>
+
+        <td>http://inspire.ec.europa.eu/codelist/GeometryMethodValue/byAdministrator</td></tr><tr>
+        <td class="w-25">position_specification</td>
+
+        <td>entrance</td></tr><tr>
+        <td class="w-25">position_specification_href</td>
+
+        <td>http://inspire.ec.europa.eu/codelist/GeometrySpecificationValue/entrance</td></tr><tr>
+        <td class="w-25">status</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">status_href</td>
+
+        <td></td></tr><tr>
+        <td class="w-25">validfrom</td>
+
+        <td>2009-12-21T00:00:00Z</td></tr><tr>
+        <td class="w-25">validto</td>
+
+        <td></td></tr>
+
+
+    </tbody>
+</table>


### PR DESCRIPTION
# Description

fix: also format date/time as UTC in HTML when viewing a single feature.

Corrects https://github.com/PDOK/gokoala/commit/be9e8b0a58c44b165b9a2fa530ee92a408ed7fd1 since this was only applied one features.go.html not feature.go.html (maybe in the future we'll try to reduce this duplication by creating a separate proeprties.go.html, but this requires some refactoring).

## Type of change

- Bugfix

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR