### PR TITLE
fix: typo in OpenAPI spec

### DIFF
--- a/internal/engine/templates/openapi/styles.go.json
+++ b/internal/engine/templates/openapi/styles.go.json
@@ -783,7 +783,7 @@
             "number": "queryable-number",
             "integer": "queryable-number",
             "date": "queryable-date",
-            "dateTime": "queryable-dateTie",
+            "dateTime": "queryable-dateTime",
             "boolean": "queryable-boolean"
           }
         }


### PR DESCRIPTION
# Description

as reported by https://geoforum.nl/t/typefoutje-in-bgt-ogc-features-api/10610

## Type of change

- Minor change (typo, formatting, version bump)

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR