### PR TITLE
chore: tweak golangci-lint after migrating from v1 to v2.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -88,7 +88,6 @@ linters:
     - nestif                    # Reports deeply nested if statements.
     - nilerr                    # Find the code that returns nil even if it checks that the error is not nil.
     - nilnesserr                # Reports constructs that checks for err != nil, but returns a different nil value error.
-    - nlreturn                  # Checks for a new line before return and branch statements to increase code clarity.
     - nolintlint                # Reports ill-formed or insufficient nolint directives.
     - nosprintfhostport         # Checks for misuse of Sprintf to construct a host with port in a URL.
     - perfsprint                # Checks that fmt.Sprintf can be replaced with a faster alternative.
@@ -178,6 +177,31 @@ linters:
         - github.com/docker/compose/v2
     revive:
       rules:
+        # default rules
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: empty-block
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: exported
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: unexported-return
+        - name: unreachable-code
+        - name: unused-parameter
+        - name: var-declaration
+        # enabled or tweaked by us
+        - name: use-any
         - name: var-naming
           arguments:
             - [ "ID" ] # AllowList

--- a/config/config.go
+++ b/config/config.go
@@ -114,7 +114,7 @@ func NewConfig(configFile string) (*Config, error) {
 }
 
 // UnmarshalYAML hooks into unmarshalling to set defaults and validate config.
-func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 	type cfg Config
 	if err := unmarshal((*cfg)(c)); err != nil {
 		return err

--- a/config/duration.go
+++ b/config/duration.go
@@ -28,7 +28,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 
 // MarshalYAML turn duration tag into YAML
 // Value instead of pointer receiver because only that way it can be used for both.
-func (d Duration) MarshalYAML() (interface{}, error) {
+func (d Duration) MarshalYAML() (any, error) {
 	return d.Duration, nil
 }
 

--- a/config/mediatype.go
+++ b/config/mediatype.go
@@ -35,7 +35,7 @@ func (m *MediaType) UnmarshalJSON(b []byte) error {
 
 // MarshalYAML turns MediaType into YAML.
 // Value instead of pointer receiver because only that way it can be used for both.
-func (m MediaType) MarshalYAML() (interface{}, error) {
+func (m MediaType) MarshalYAML() (any, error) {
 	return m.String(), nil
 }
 

--- a/config/url.go
+++ b/config/url.go
@@ -61,7 +61,7 @@ func (u *URL) UnmarshalJSON(b []byte) error {
 
 // MarshalYAML turns URL into YAML.
 // Value instead of pointer receiver because only that way it can be used for both.
-func (u URL) MarshalYAML() (interface{}, error) {
+func (u URL) MarshalYAML() (any, error) {
 	if u.URL == nil {
 		return "", nil
 	}

--- a/internal/ogc/features/datasources/geopackage/encoding/geopackage_test.go
+++ b/internal/ogc/features/datasources/geopackage/encoding/geopackage_test.go
@@ -215,9 +215,7 @@ func TestBinaryHeader(t *testing.T) {
 			}
 			if err != nil {
 				t.Errorf("error, expected nil got %v", err.Error())
-
 				return
-
 			}
 
 			if bh.Version() != tc.version {


### PR DESCRIPTION
# Description

Specifically avoid disabling all revive rules by tweaking the var-naming rule

## Type of change

- Configuration change

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR