### PR TITLE
feat(cql): extend CQL support

### DIFF
--- a/internal/engine/types/stack.go
+++ b/internal/engine/types/stack.go
@@ -24,7 +24,7 @@ func (s *Stack) Pop() string {
 }
 
 func (s *Stack) PopMany(count int) []string {
-	if count <= 1 {
+	if count <= 0 {
 		return nil
 	}
 	if count > len(s.stack) {

--- a/internal/ogc/features/cql/cql.go
+++ b/internal/ogc/features/cql/cql.go
@@ -72,8 +72,8 @@ func (c *ErrorListener) SyntaxError(_ antlr.Recognizer, _ any, _, column int, ms
 	c.parseErrors = append(c.parseErrors, fmt.Errorf("syntax error at column %d: %s", column, msg))
 }
 
-// ListenerError is called by our own CQL-to-SQL listeners when an error occurs.
-func (c *ErrorListener) ListenerError(msg string) {
+// Error is called by our own CQL-to-SQL listeners when an error occurs.
+func (c *ErrorListener) Error(msg string) {
 	c.parseErrors = append(c.parseErrors, fmt.Errorf("error: %s", msg))
 }
 

--- a/internal/ogc/features/cql/listener_common.go
+++ b/internal/ogc/features/cql/listener_common.go
@@ -62,6 +62,21 @@ func (cl *CommonListener) allowAllQueryables() bool {
 	return len(cl.queryables) == 1 && cl.queryables[0] == "*"
 }
 
+// hasWildcard checks if a pattern contains a SQL wildcard: % or _.
+func (cl *CommonListener) hasWildcard(pattern string, symbol string) bool {
+	namedParam := pattern
+	if strings.HasPrefix(pattern, symbol) {
+		namedParam = pattern[len(symbol):] // remove symbol
+	}
+	patternValue, ok := cl.namedParams[namedParam]
+	if !ok {
+		return false
+	}
+	patternValueStr := fmt.Sprintf("%v", patternValue)
+	return strings.Contains(patternValueStr, "%") ||
+		strings.Contains(patternValueStr, "_")
+}
+
 func parseNumber(s string) (any, error) {
 	s = strings.TrimSpace(s)
 

--- a/internal/ogc/features/cql/listener_geopackage.go
+++ b/internal/ogc/features/cql/listener_geopackage.go
@@ -60,8 +60,66 @@ func (l *GeoPackageListener) ExitBooleanFactor(ctx *parser.BooleanFactorContext)
 func (l *GeoPackageListener) ExitBinaryComparisonPredicate(ctx *parser.BinaryComparisonPredicateContext) {
 	right := l.stack.Pop()
 	left := l.stack.Pop()
-	op := ctx.ComparisonOperator().GetText()
-	l.stack.Push(fmt.Sprintf("%s %s %s", left, op, right))
+	operator := ctx.ComparisonOperator().GetText()
+	l.stack.Push(fmt.Sprintf("%s %s %s", left, operator, right))
+}
+
+// ExitIsLikePredicate Comparison expressions (LIKE, NOT LIKE)
+func (l *GeoPackageListener) ExitIsLikePredicate(ctx *parser.IsLikePredicateContext) {
+	pattern := l.stack.Pop()
+	expr := l.stack.Pop()
+
+	if !l.hasWildcard(pattern, geopackage.NamedParamSymbolSqlx) {
+		l.errorListener.Error("LIKE pattern is missing wildcard symbol. " +
+			"Either percentage '%' to match multiple characters or underscore '_' to " +
+			"match a single character can be used as a wildcard symbol. For example: LIKE 'foo%'.")
+		return
+	}
+
+	operator := "LIKE"
+	if ctx.NOT() != nil {
+		operator = "NOT " + operator
+	}
+	l.stack.Push(fmt.Sprintf("%s %s %s", expr, operator, pattern))
+}
+
+// ExitIsBetweenPredicate Comparison expressions (BETWEEN, NOT BETWEEN)
+func (l *GeoPackageListener) ExitIsBetweenPredicate(ctx *parser.IsBetweenPredicateContext) {
+	high := l.stack.Pop()
+	low := l.stack.Pop()
+	expr := l.stack.Pop()
+
+	operator := "BETWEEN"
+	if ctx.NOT() != nil {
+		operator = "NOT " + operator
+	}
+	l.stack.Push(fmt.Sprintf("%s %s %s AND %s", expr, operator, low, high))
+}
+
+// ExitIsInListPredicate Comparison expressions (IN, NOT IN)
+func (l *GeoPackageListener) ExitIsInListPredicate(ctx *parser.IsInListPredicateContext) {
+	count := len(ctx.AllScalarExpression())
+	if count > 1 {
+		items := l.stack.PopMany(count - 1)
+		expr := l.stack.Pop()
+
+		operator := "IN"
+		if ctx.NOT() != nil {
+			operator = "NOT " + operator
+		}
+		l.stack.Push(fmt.Sprintf("%s %s (%s)", expr, operator, strings.Join(items, ", ")))
+	}
+}
+
+// ExitIsNullPredicate Comparison expressions (IS NULL, IS NOT NULL)
+func (l *GeoPackageListener) ExitIsNullPredicate(ctx *parser.IsNullPredicateContext) {
+	expr := l.stack.Pop()
+
+	operator := "IS NULL"
+	if ctx.NOT() != nil {
+		operator = "IS NOT NULL"
+	}
+	l.stack.Push(fmt.Sprintf("%s %s", expr, operator))
 }
 
 // ExitPropertyName Handle column names
@@ -69,9 +127,12 @@ func (l *GeoPackageListener) ExitPropertyName(ctx *parser.PropertyNameContext) {
 	name := ctx.GetText()
 	if !l.allowAllQueryables() && !slices.Contains(l.queryables, name) {
 		err := fmt.Sprintf("property '%s' cannot be used in CQL filter, is not a queryable property", name)
-		l.errorListener.ListenerError(err)
+		l.errorListener.Error(err)
 		return
 	}
+
+	// escape named param symbol, since it can also appear in property names
+	name = strings.ReplaceAll(name, geopackage.NamedParamSymbolSqlx, geopackage.NamedParamSymbolSqlxEscaped)
 
 	// add quotes around column names if not already present
 	if !strings.HasPrefix(name, "\"") {
@@ -97,7 +158,7 @@ func (l *GeoPackageListener) ExitNumericLiteral(ctx *parser.NumericLiteralContex
 
 		num, err := parseNumber(ctx.GetText())
 		if err != nil {
-			l.errorListener.ListenerError(err.Error())
+			l.errorListener.Error(err.Error())
 			return
 		}
 

--- a/internal/ogc/features/cql/listener_geopackage_test.go
+++ b/internal/ogc/features/cql/listener_geopackage_test.go
@@ -2,6 +2,7 @@ package cql
 
 import (
 	"database/sql"
+	"log"
 	"os"
 	"path"
 	"runtime"
@@ -33,7 +34,7 @@ func loadExtensions() {
 	})
 }
 
-func TestInvalidBooleanExpression(t *testing.T) {
+func TestInvalidBooleanQuery(t *testing.T) {
 	// given
 	inputCQL := "prop1 ==== 1 AND prop2 !!= 5"
 
@@ -46,7 +47,7 @@ func TestInvalidBooleanExpression(t *testing.T) {
 	assert.Empty(t, params)
 }
 
-func TestFailOnNonQueryablePropertyExpression(t *testing.T) {
+func TestFailOnNonQueryablePropertyQuery(t *testing.T) {
 	// given
 	queryables := []string{"prop1"}
 	inputCQL := "prop1 = 30 AND prop2 > 77"
@@ -58,7 +59,7 @@ func TestFailOnNonQueryablePropertyExpression(t *testing.T) {
 	assert.ErrorContains(t, err, "property 'prop2' cannot be used in CQL filter, is not a queryable property")
 }
 
-func TestBooleanExpressionWithNumbers(t *testing.T) {
+func TestBooleanQueryWithNumbers(t *testing.T) {
 	// given
 	queryables := []string{"prop1", "prop2"}
 	inputCQL := "prop1 = 10 AND prop2 < 5"
@@ -74,7 +75,7 @@ func TestBooleanExpressionWithNumbers(t *testing.T) {
 	assert.Equal(t, expectedSQL, actualSQL)
 }
 
-func TestMultipleBooleanExpressions(t *testing.T) {
+func TestMultipleBooleanQueries(t *testing.T) {
 	// given
 	queryables := []string{"prop1", "prop2"}
 	inputCQL := "(prop1 = 10 OR prop1 = 20) AND NOT (prop2 = 'X')"
@@ -90,7 +91,23 @@ func TestMultipleBooleanExpressions(t *testing.T) {
 	assert.Equal(t, expectedSQL, actualSQL)
 }
 
-func TestMultipleBooleanExpressionsWithStrings(t *testing.T) {
+func TestBooleanLiterals(t *testing.T) {
+	// given
+	queryables := []string{"prop1", "prop2"}
+	inputCQL := "(prop1 = true OR prop2 = 20)"
+	expectedSQL := "(\"prop1\" = 1 OR \"prop2\" = :cql_bcde)"
+
+	// when
+	actualSQL, params, err := ParseToSQL(inputCQL, NewGeoPackageListener(&util.MockRandomizer{}, queryables))
+
+	// then
+	require.NoError(t, err)
+	assertValidSQLiteQuery(t, actualSQL, params)
+	assert.Equal(t, map[string]any{"cql_bcde": int64(20)}, params)
+	assert.Equal(t, expectedSQL, actualSQL)
+}
+
+func TestMultipleBooleanQueriesWithStrings(t *testing.T) {
 	// given
 	queryables := []string{"prop1", "prop2", "prop3"}
 	inputCQL := "(prop1 = 'foo' AND prop2 = 'bar') OR prop3 = 'abc'"
@@ -106,7 +123,162 @@ func TestMultipleBooleanExpressionsWithStrings(t *testing.T) {
 	assert.Equal(t, expectedSQL, actualSQL)
 }
 
-// TODO: enable once implementation is further completed!!
+func TestLikeOperator(t *testing.T) {
+	// given
+	queryables := []string{"prop1", "prop2", "prop3"}
+	inputCQL := "prop1 LIKE 'foo%' AND prop2 LIKE 'bar_' OR prop3 LIKE '%abc'"
+	expectedSQL := "((\"prop1\" LIKE :cql_bcde AND \"prop2\" LIKE :cql_fghi) OR \"prop3\" LIKE :cql_jklm)"
+
+	// when
+	actualSQL, params, err := ParseToSQL(inputCQL, NewGeoPackageListener(&util.MockRandomizer{}, queryables))
+
+	// then
+	require.NoError(t, err)
+	assertValidSQLiteQuery(t, actualSQL, params)
+	assert.Equal(t, map[string]any{"cql_bcde": "'foo%'", "cql_fghi": "'bar_'", "cql_jklm": "'%abc'"}, params)
+	assert.Equal(t, expectedSQL, actualSQL)
+}
+
+func TestNotLikeOperator(t *testing.T) {
+	// given
+	queryables := []string{"prop1", "prop2", "prop3"}
+	inputCQL := "prop1 NOT LIKE 'foo%' AND prop2 LIKE 'bar_' OR prop3 LIKE '%abc'"
+	expectedSQL := "((\"prop1\" NOT LIKE :cql_bcde AND \"prop2\" LIKE :cql_fghi) OR \"prop3\" LIKE :cql_jklm)"
+
+	// when
+	actualSQL, params, err := ParseToSQL(inputCQL, NewGeoPackageListener(&util.MockRandomizer{}, queryables))
+
+	// then
+	require.NoError(t, err)
+	assertValidSQLiteQuery(t, actualSQL, params)
+	assert.Equal(t, map[string]any{"cql_bcde": "'foo%'", "cql_fghi": "'bar_'", "cql_jklm": "'%abc'"}, params)
+	assert.Equal(t, expectedSQL, actualSQL)
+}
+
+func TestLikeOperatorFailOnMissingWildcard(t *testing.T) {
+	// given
+	queryables := []string{"prop1"}
+	inputCQL := "prop1 LIKE 'foo'"
+
+	// when
+	_, _, err := ParseToSQL(inputCQL, NewGeoPackageListener(&util.MockRandomizer{}, queryables))
+
+	// then
+	assert.ErrorContains(t, err, "LIKE pattern is missing wildcard symbol. "+
+		"Either percentage '%' to match multiple characters or underscore '_' to match a "+
+		"single character can be used as a wildcard symbol. For example: LIKE 'foo%'.")
+}
+
+func TestBetweenOperator(t *testing.T) {
+	// given
+	queryables := []string{"prop1", "prop2"}
+	inputCQL := "prop1 BETWEEN 4 AND 6 AND prop2 = 'bar'"
+	expectedSQL := "(\"prop1\" BETWEEN :cql_bcde AND :cql_fghi AND \"prop2\" = :cql_jklm)"
+
+	// when
+	actualSQL, params, err := ParseToSQL(inputCQL, NewGeoPackageListener(&util.MockRandomizer{}, queryables))
+
+	// then
+	require.NoError(t, err)
+	assertValidSQLiteQuery(t, actualSQL, params)
+	assert.Equal(t, map[string]any{"cql_bcde": int64(4), "cql_fghi": int64(6), "cql_jklm": "'bar'"}, params)
+	assert.Equal(t, expectedSQL, actualSQL)
+}
+
+func TestNotBetweenOperator(t *testing.T) {
+	// given
+	queryables := []string{"prop1", "prop2"}
+	inputCQL := "prop1 NOT BETWEEN 4 AND 6 AND prop2 = 'bar'"
+	expectedSQL := "(\"prop1\" NOT BETWEEN :cql_bcde AND :cql_fghi AND \"prop2\" = :cql_jklm)"
+
+	// when
+	actualSQL, params, err := ParseToSQL(inputCQL, NewGeoPackageListener(&util.MockRandomizer{}, queryables))
+
+	// then
+	require.NoError(t, err)
+	assertValidSQLiteQuery(t, actualSQL, params)
+	assert.Equal(t, map[string]any{"cql_bcde": int64(4), "cql_fghi": int64(6), "cql_jklm": "'bar'"}, params)
+	assert.Equal(t, expectedSQL, actualSQL)
+}
+
+func TestInListOperator(t *testing.T) {
+	// given
+	queryables := []string{"prop1", "prop2"}
+	inputCQL := "prop1 IN ('foo', 'bar', 'baz') AND prop2 = 'baz'"
+	expectedSQL := "(\"prop1\" IN (:cql_bcde, :cql_fghi, :cql_jklm) AND \"prop2\" = :cql_nopq)"
+
+	// when
+	actualSQL, params, err := ParseToSQL(inputCQL, NewGeoPackageListener(&util.MockRandomizer{}, queryables))
+
+	// then
+	require.NoError(t, err)
+	assertValidSQLiteQuery(t, actualSQL, params)
+	assert.Equal(t, map[string]any{"cql_bcde": "'foo'", "cql_fghi": "'bar'", "cql_jklm": "'baz'", "cql_nopq": "'baz'"}, params)
+	assert.Equal(t, expectedSQL, actualSQL)
+}
+
+func TestNotInListOperator(t *testing.T) {
+	// given
+	queryables := []string{"prop1", "prop2"}
+	inputCQL := "prop1 NOT IN ('foo', 'bar', 'baz') AND prop2 = 'baz'"
+	expectedSQL := "(\"prop1\" NOT IN (:cql_bcde, :cql_fghi, :cql_jklm) AND \"prop2\" = :cql_nopq)"
+
+	// when
+	actualSQL, params, err := ParseToSQL(inputCQL, NewGeoPackageListener(&util.MockRandomizer{}, queryables))
+
+	// then
+	require.NoError(t, err)
+	assertValidSQLiteQuery(t, actualSQL, params)
+	assert.Equal(t, map[string]any{"cql_bcde": "'foo'", "cql_fghi": "'bar'", "cql_jklm": "'baz'", "cql_nopq": "'baz'"}, params)
+	assert.Equal(t, expectedSQL, actualSQL)
+}
+
+func TestIsNullOperator(t *testing.T) {
+	// given
+	queryables := []string{"prop1", "prop2"}
+	inputCQL := "prop1 IS NULL AND prop2 = 'baz'"
+	expectedSQL := "(\"prop1\" IS NULL AND \"prop2\" = :cql_bcde)"
+
+	// when
+	actualSQL, params, err := ParseToSQL(inputCQL, NewGeoPackageListener(&util.MockRandomizer{}, queryables))
+
+	// then
+	require.NoError(t, err)
+	assertValidSQLiteQuery(t, actualSQL, params)
+	assert.Equal(t, map[string]any{"cql_bcde": "'baz'"}, params)
+	assert.Equal(t, expectedSQL, actualSQL)
+}
+
+func TestIsNotNullOperator(t *testing.T) {
+	// given
+	queryables := []string{"prop1", "prop2"}
+	inputCQL := "prop1 IS NOT NULL AND prop2 = 'baz'"
+	expectedSQL := "(\"prop1\" IS NOT NULL AND \"prop2\" = :cql_bcde)"
+
+	// when
+	actualSQL, params, err := ParseToSQL(inputCQL, NewGeoPackageListener(&util.MockRandomizer{}, queryables))
+
+	// then
+	require.NoError(t, err)
+	assertValidSQLiteQuery(t, actualSQL, params)
+	assert.Equal(t, map[string]any{"cql_bcde": "'baz'"}, params)
+	assert.Equal(t, expectedSQL, actualSQL)
+}
+
+func TestFailOnInvalidInListQuery(t *testing.T) {
+	// given
+	queryables := []string{"prop1", "prop2"}
+	inputCQL := "prop1 IN ('foo', 'bar' 'baz')"
+
+	// when
+	_, _, err := ParseToSQL(inputCQL, NewGeoPackageListener(&util.MockRandomizer{}, queryables))
+
+	// then
+	assert.ErrorContains(t, err, "syntax error at column 23: extraneous input ''baz'' expecting {')', ','}")
+}
+
+// Test CQL examples provided by OGC.
+// See https://github.com/opengeospatial/ogcapi-features/tree/64ac2d892b877b711a4570336cb9d42e2afb4ef8/cql2/standard/schema/examples/text
 func TestCQLExamplesProvidedByOGC(t *testing.T) {
 	ogcExamples := path.Join(pwd, "testdata", "ogc")
 
@@ -124,8 +296,9 @@ func TestCQLExamplesProvidedByOGC(t *testing.T) {
 			example, err := os.ReadFile(path.Join(ogcExamples, entry.Name()))
 			require.NoError(t, err)
 
-			inputCQL := strings.TrimSpace(string(example))
+			inputCQL := strings.Map(removeNewlinesAndTabs, strings.TrimSpace(string(example)))
 			require.NotEmpty(t, inputCQL)
+			log.Printf("Parsing CQL: %s", inputCQL)
 
 			queryables := []string{"*"} // allow all
 			actualSQL, params, err := ParseToSQL(inputCQL, NewGeoPackageListener(&util.MockRandomizer{}, queryables))
@@ -135,6 +308,13 @@ func TestCQLExamplesProvidedByOGC(t *testing.T) {
 			assertValidSQLiteQuery(t, actualSQL, params)
 		})
 	}
+}
+
+func removeNewlinesAndTabs(r rune) rune {
+	if r == '\n' || r == '\r' || r == '\t' {
+		return -1
+	}
+	return r
 }
 
 func assertValidSQLiteQuery(t *testing.T, filter string, params map[string]any) {
@@ -150,5 +330,10 @@ func assertValidSQLiteQuery(t *testing.T, filter string, params map[string]any) 
 	query := "select * from cql where " + filter
 	rows, err := db.NamedQuery(query, params)
 	require.NoError(t, err)
+
 	defer rows.Close()
+	for rows.Next() {
+		_ = rows.Scan()
+	}
+	require.NoError(t, rows.Err())
 }

--- a/internal/ogc/features/cql/parser/CqlLexer.g4
+++ b/internal/ogc/features/cql/parser/CqlLexer.g4
@@ -2,7 +2,8 @@
  * ------------------
  * Note: This file is based on https://github.com/ldproxy/xtraplatform-spatial/blob/482b607f6709389fcd43ebea7dd0434389b8011b/
  * xtraplatform-cql/src/main/antlr/de/ii/xtraplatform/cql/infra/CqlLexer.g4
- *
+ * But modified by PDOK.
+  *
  * Keep the following license header intact:
  * ------------------
  *

--- a/internal/ogc/features/cql/parser/CqlParser.g4
+++ b/internal/ogc/features/cql/parser/CqlParser.g4
@@ -2,6 +2,7 @@
  * ------------------
  * Note: This file is based on https://github.com/ldproxy/xtraplatform-spatial/blob/482b607f6709389fcd43ebea7dd0434389b8011b/
  * xtraplatform-cql/src/main/antlr/de/ii/xtraplatform/cql/infra/CqlParser.g4
+ * But modified by PDOK.
  *
  * Keep the following license header intact:
  * ------------------

--- a/internal/ogc/features/datasources/geopackage/geopackage.go
+++ b/internal/ogc/features/datasources/geopackage/geopackage.go
@@ -29,7 +29,8 @@ const (
 	sqliteDriverName = "sqlite3_with_extensions"
 
 	// NamedParamSymbolSqlx https://jmoiron.github.io/sqlx/#namedParams
-	NamedParamSymbolSqlx = ":"
+	NamedParamSymbolSqlx        = ":"
+	NamedParamSymbolSqlxEscaped = "::"
 )
 
 var once sync.Once

--- a/internal/ogc/features/features.go
+++ b/internal/ogc/features/features.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/PDOK/gokoala/config"
@@ -224,5 +225,5 @@ func (f *Features) parseCQL(cqlFilter string, datasource ds.Datasource, schema d
 		// make SQL filter appendable to the existing WHERE clause
 		sql = "and " + sql
 	}
-	return ds.Part3Filter{SQL: sql, Params: params}, err
+	return ds.Part3Filter{SQL: strings.ToLower(sql), Params: params}, err
 }


### PR DESCRIPTION
# Description

Expand parsing of CQL to SQL for GeoPackages (SQLite with SpatiaLite). This includes:

- support for LIKE, NOT LIKE
- support for BETWEEN, NOT BETWEEN
- support for IN and NOT IN
- support for IS NULL and IS NOT NULL

## Type of change

- Improvement of existing feature

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR