### PR TITLE
chore(deps): include sqlite amalgamation sourcecode once

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Unit Test
         run: |
+          set -o pipefail
+
           go test -v -race -shuffle=on \
             -coverpkg "$(go list || go list -m | head -1)/..." \
             -coverprofile cover.out.tmp \

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ toolchain go1.26.2
 
 require (
 	dario.cat/mergo v1.0.2
-	github.com/PDOK/go-cloud-sqlite-vfs v0.4.0
+	github.com/PDOK/go-cloud-sqlite-vfs v0.4.1
 	github.com/antlr4-go/antlr/v4 v4.13.1
 	github.com/creasty/defaults v1.8.0
 	github.com/docker/go-units v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.14.1 h1:CMuB3fqQVfPdhyXhUqYdUmPUIOhJkmghCx3dJet8Cqs=
 github.com/Microsoft/hcsshim v0.14.1/go.mod h1:VnzvPLyWUhxiPVsJ31P6XadxCcTogTguBFDy/1GR/OM=
-github.com/PDOK/go-cloud-sqlite-vfs v0.4.0 h1:92iHDI2jR9GQfcqk1vDi67bMfq4CWDg+sXPUMiCnL9U=
-github.com/PDOK/go-cloud-sqlite-vfs v0.4.0/go.mod h1:+mZxO6New9AlVqFAF2rBEsOZB7J2aavwtdn3ifg021s=
+github.com/PDOK/go-cloud-sqlite-vfs v0.4.1 h1:jdVmXidQtrDm3+mawtcnKH7sQxHsHXjrHXPlyut3fEI=
+github.com/PDOK/go-cloud-sqlite-vfs v0.4.1/go.mod h1:GrDvq3JHq4tASopACZpO0nB9Rky3ESwD+7tqo3C4fOA=
 github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBiRGFrw=
 github.com/ProtonMail/go-crypto v1.3.0/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=


### PR DESCRIPTION
# Description

chore(deps): bump go-cloud-sqlite-vfs to v0.4.1. This includes the sqlite amalgamation sourcecode only once though mattn/go-sqlite and NOT also though pdok/go-cloud-sqlite-vfs.

## Type of change

- Minor change (typo, formatting, version bump)

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR