### PR TITLE
fix: add missing API-Version header in OpenAPI spec for search endpoint

### DIFF
--- a/internal/engine/templates/openapi/features-search.go.json
+++ b/internal/engine/templates/openapi/features-search.go.json
@@ -51,7 +51,8 @@
                   "type": "string"
                 },
                 "example": "<http://www.opengis.net/def/crs/EPSG/0/3395>"
-              }
+              },
+              {{block "headers" . }}{{end}}
             },
             "content": {
               "application/geo+json": {


### PR DESCRIPTION
# Description

fix: add missing API-Version header in OpenAPI spec for search endpoint

## Type of change

- Bugfix

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR