### PR TITLE
fix(cql): hide filter in OpenAPI when CQL is disabled

### DIFF
--- a/internal/engine/templates/openapi/features.go.json
+++ b/internal/engine/templates/openapi/features.go.json
@@ -57,7 +57,7 @@
             "$ref": "#/components/parameters/datetime_notsupported"
           },
           {{ end }}
-          {{ if and $coll.Filters $coll.Filters.CQL $coll.Filters.CQL.Enable }}
+          {{ if and $coll.Filters $coll.Filters.CQL $coll.Filters.CQL.IsEnabled }}
           {
             "$ref" : "#/components/parameters/filter"
           },


### PR DESCRIPTION
# Description

fix(cql): hide filter in OpenAPI when CQL is disabled

## Type of change

- Bugfix

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR