### PR TITLE
feat(config): allow for URL as thumbnail as well as full path and filename

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/creasty/defaults"
 	"github.com/go-playground/validator/v10"
@@ -292,11 +293,12 @@ func validateLocalPaths(config *Config) error {
 
 // make sure resources dir/url is configured when config contains references to files like thumbnails or legends.
 func validateConfiguredResources(config *Config) error {
-	if config.Thumbnail != nil {
-		return errors.New("thumbnail cannot be used when 'resources' isn't specified")
+	if config.Thumbnail != nil && !strings.Contains(*config.Thumbnail, "/") {
+		return errors.New("when resources.directory is not set the thumbnail should contain a full path or URL to an image")
 	}
 	for _, coll := range config.AllCollections() {
-		if coll.GetMetadata() != nil && coll.GetMetadata().Thumbnail != nil {
+		if coll.GetMetadata() != nil && coll.GetMetadata().Thumbnail != nil &&
+			!strings.Contains(*coll.GetMetadata().Thumbnail, "/") {
 			return fmt.Errorf("thumbnail for collection %s cannot be used when 'resources' isn't specified", coll.GetID())
 		}
 	}

--- a/internal/engine/resources.go
+++ b/internal/engine/resources.go
@@ -4,6 +4,8 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"path"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -14,21 +16,94 @@ func newResourcesEndpoint(e *Engine) {
 	if res == nil {
 		return
 	}
+
+	assets := gatherAssets(e)
+
+	for asset := range assets {
+		assetFilename := extractFilenameFromPath(asset)
+		if assetFilename == "" {
+			continue
+		}
+		if isURL(&asset) {
+			// Provision the reverse proxy resource
+			e.Router.Handle("/resources/"+assetFilename,
+				proxy(e.ReverseProxy, strings.TrimSuffix(asset, "/"+assetFilename), assetFilename),
+			)
+		} else {
+			e.Router.Handle("/resources/"+assetFilename, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.ServeFile(w, r, asset)
+			}))
+		}
+	}
+
 	var resourcesHandler http.Handler
 	if res.Directory != nil && *res.Directory != "" {
 		resourcesPath := *res.Directory
 		resourcesHandler = http.StripPrefix("/resources", http.FileServer(http.Dir(resourcesPath)))
 	} else if res.URL != nil && res.URL.String() != "" {
-		resourcesHandler = proxy(e.ReverseProxy, res.URL.String())
+		resourcesHandler = proxy(e.ReverseProxy, res.URL.String(), "")
 	}
+	// The wildcard handle is added last since specific routes should take priority over the wildcard route.
 	e.Router.Handle("/resources/*", resourcesHandler)
+}
+
+// Get the assets, for now, they are thumbnails that can be a filename (with or without path) or a URL.
+func gatherAssets(e *Engine) map[string]struct{} {
+	cfg := e.Config
+	assets := make(map[string]struct{})
+
+	var resourcesDir string
+	if cfg.Resources != nil && cfg.Resources.Directory != nil {
+		resourcesDir = strings.TrimPrefix(*cfg.Resources.Directory, ".")
+	}
+
+	registerAsset(assets, cfg.Thumbnail, resourcesDir)
+
+	for _, coll := range cfg.AllCollections() {
+		if metadata := coll.GetMetadata(); metadata != nil {
+			registerAsset(assets, metadata.Thumbnail, resourcesDir)
+		}
+	}
+
+	if cfg.OgcAPI.Styles != nil {
+		for _, style := range cfg.OgcAPI.Styles.SupportedStyles {
+			registerAsset(assets, style.Thumbnail, resourcesDir)
+		}
+	}
+
+	return assets
+}
+
+func registerAsset(assets map[string]struct{}, thumbnail *string, resourcesDir string) {
+	if thumbnail == nil {
+		return
+	}
+
+	filename := extractFilenameFromPath(*thumbnail)
+	if filename == "" {
+		return
+	}
+
+	if !isURL(thumbnail) && resourcesDir != "" && strings.Contains(*thumbnail, resourcesDir) {
+		// File already lives inside the directory served by the /resources/* wildcard.
+		*thumbnail = filename
+		return
+	}
+
+	assets[*thumbnail] = struct{}{}
+	*thumbnail = filename
 }
 
 type revProxy func(w http.ResponseWriter, r *http.Request, target *url.URL, prefer204 bool, overwrite string)
 
-func proxy(reverseProxy revProxy, resourcesURL string) http.HandlerFunc {
+func proxy(reverseProxy revProxy, resourcesURL string, resourceName string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		resourcePath, _ := url.JoinPath("/", chi.URLParam(r, "*"))
+		var resourcePath string
+		if resourceName != "" {
+			resourcePath = "/" + resourceName
+		} else {
+			resourcePath, _ = url.JoinPath("/", chi.URLParam(r, "*"))
+		}
 		target, err := url.ParseRequestURI(resourcesURL + resourcePath)
 		if err != nil {
 			log.Printf("invalid target url, can't proxy resources: %v", err)
@@ -38,4 +113,26 @@ func proxy(reverseProxy revProxy, resourcesURL string) http.HandlerFunc {
 		}
 		reverseProxy(w, r, target, false, "")
 	}
+}
+
+func extractFilenameFromPath(urlPath string) string {
+	u, err := url.Parse(urlPath)
+	if err != nil {
+		return ""
+	}
+	ext := path.Ext(u.Path)
+	if ext == "" {
+		return ""
+	}
+	// Extension found (above), so we can assume there is a filename in the path.
+	urlParts := strings.Split(urlPath, "/")
+	if len(urlParts) <= 1 {
+		return ""
+	}
+	return urlParts[len(urlParts)-1]
+}
+
+func isURL(thumbnail *string) bool {
+	return strings.HasPrefix(*thumbnail, "http://") ||
+		strings.HasPrefix(*thumbnail, "https://")
 }

--- a/internal/engine/resources_test.go
+++ b/internal/engine/resources_test.go
@@ -106,7 +106,7 @@ func TestProxy(t *testing.T) {
 			log.SetOutput(&logOutput)
 
 			// when
-			proxyHandler := proxy(mockReverseProxy.Proxy, tt.resourcesURL)
+			proxyHandler := proxy(mockReverseProxy.Proxy, tt.resourcesURL, "")
 			proxyHandler(w, r)
 
 			// then
@@ -121,4 +121,129 @@ func TestProxy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProxyWithResourceName(t *testing.T) {
+	tests := []struct {
+		name           string
+		resourcesURL   string
+		resourceName   string
+		expectedStatus int
+		expectProxy    bool
+	}{
+		{
+			name:           "proxy with specific resource name",
+			resourcesURL:   "http://example.com/resources",
+			resourceName:   "logo.png",
+			expectedStatus: http.StatusOK,
+			expectProxy:    true,
+		},
+		{
+			name:           "invalid url with resource name",
+			resourcesURL:   "foo bar",
+			resourceName:   "logo.png",
+			expectedStatus: http.StatusInternalServerError,
+			expectProxy:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given
+			mockReverseProxy := MockReverseProxy{}
+			if tt.expectProxy {
+				mockReverseProxy.On("Proxy", mock.Anything, mock.Anything, mock.Anything, false, "").Return()
+			}
+			r := httptest.NewRequest(http.MethodGet, "/resources/dummy", nil)
+			w := httptest.NewRecorder()
+			var logOutput strings.Builder
+			log.SetOutput(&logOutput)
+
+			// when
+			proxyHandler := proxy(mockReverseProxy.Proxy, tt.resourcesURL, tt.resourceName)
+			proxyHandler(w, r)
+
+			// then
+			assert.Equal(t, tt.expectedStatus, w.Result().StatusCode)
+			if tt.expectProxy {
+				mockReverseProxy.AssertCalled(t, "Proxy", mock.Anything, mock.Anything, mock.MatchedBy(func(u *url.URL) bool {
+					return strings.Contains(u.String(), tt.resourceName)
+				}), false, "")
+			}
+		})
+	}
+}
+
+func TestRegisterAsset(t *testing.T) {
+	tests := []struct {
+		name           string
+		thumbnail      string
+		resourcesDir   string
+		shouldRegister bool
+		expectedValue  string
+	}{
+		{
+			name:           "local file with path",
+			thumbnail:      "assets/logo.png",
+			resourcesDir:   "",
+			shouldRegister: true,
+			expectedValue:  "logo.png",
+		},
+		{
+			name:           "remote http url",
+			thumbnail:      "http://example.com/assets/logo.png",
+			resourcesDir:   "",
+			shouldRegister: true,
+			expectedValue:  "logo.png",
+		},
+		{
+			name:           "remote https url",
+			thumbnail:      "https://example.com/assets/logo.png",
+			resourcesDir:   "",
+			shouldRegister: true,
+			expectedValue:  "logo.png",
+		},
+		{
+			name:           "file inside resources directory",
+			thumbnail:      "/resources/logo.png",
+			resourcesDir:   "/resources",
+			shouldRegister: false,
+			expectedValue:  "logo.png",
+		},
+		{
+			name:           "filename without path returns empty",
+			thumbnail:      "logo.png",
+			resourcesDir:   "",
+			shouldRegister: false,
+			expectedValue:  "logo.png",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given
+			assets := make(map[string]struct{})
+			thumbnail := tt.thumbnail
+
+			// when
+			registerAsset(assets, &thumbnail, tt.resourcesDir)
+
+			// then
+			assert.Equal(t, tt.expectedValue, thumbnail)
+			if tt.shouldRegister {
+				assert.Contains(t, assets, tt.thumbnail)
+			} else {
+				assert.NotContains(t, assets, tt.thumbnail)
+			}
+		})
+	}
+}
+
+func TestRegisterAssetWithNil(t *testing.T) {
+	// given
+	assets := make(map[string]struct{})
+
+	// when
+	registerAsset(assets, nil, "")
+
+	// then
+	assert.Empty(t, assets)
 }


### PR DESCRIPTION
# Description

A more flexible approach to accepting images as thumbnail, while still supporting the old way

## Type of change

- New feature


# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR