### PR TITLE
fix(cql): only create unaccent, postgis should already be there

### DIFF
--- a/internal/ogc/features/datasources/postgres/driver.go
+++ b/internal/ogc/features/datasources/postgres/driver.go
@@ -11,7 +11,7 @@ import (
 	pgxuuid "github.com/vgarvardt/pgx-google-uuid/v5"
 )
 
-var postgresExtensions = []string{"postgis", "unaccent"}
+var postgresExtensions = []string{"unaccent"}
 
 // InitConnectionPool initializes a connection pool for the given connection string and runs setup queries.
 func InitConnectionPool(ctx context.Context, connectionString string) (*pgxpool.Pool, error) {


### PR DESCRIPTION
# Description

_What_ have you changed and _why_?

## Type of change

- Bugfix

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR