### PR TITLE
feat: align OGC API Features part 1 and part 3 - wildcard handling

### DIFF
--- a/internal/ogc/features/datasources/common/common.go
+++ b/internal/ogc/features/datasources/common/common.go
@@ -172,9 +172,11 @@ func PropertyFiltersToSQL(pf map[string]string, symbol string) (sql string, name
 		for k, v := range pf {
 			position++
 			namedParam := fmt.Sprintf("pf%d", position)
-			// column name in double quotes in case it is a reserved keyword
-			// also: we don't currently support LIKE since wildcard searches don't use the index
-			sqlBuilder.WriteString(fmt.Sprintf(" and \"%s\" = %s%s", k, symbol, namedParam))
+			if strings.Contains(v, datasources.Wildcard) {
+				sqlBuilder.WriteString(fmt.Sprintf(" and \"%s\" like %s%s", k, symbol, namedParam))
+			} else {
+				sqlBuilder.WriteString(fmt.Sprintf(" and \"%s\" = %s%s", k, symbol, namedParam))
+			}
 			namedParams[namedParam] = v
 		}
 	}

--- a/internal/ogc/features/datasources/datasource.go
+++ b/internal/ogc/features/datasources/datasource.go
@@ -11,6 +11,8 @@ import (
 	"github.com/twpayne/go-geom"
 )
 
+const Wildcard = "%"
+
 // Datasource holds all Features for a single object type in a specific projection/CRS.
 // This abstraction allows the rest of the system to stay datastore agnostic <== IMPORTANT.
 type Datasource interface {

--- a/internal/ogc/features/features_test.go
+++ b/internal/ogc/features/features_test.go
@@ -1103,6 +1103,23 @@ func TestFeatures(t *testing.T) {
 				statusCode: http.StatusOK,
 			},
 		},
+		{
+			name: "Request features with wildcard in Part 1 property filter",
+			fields: fields{
+				configFiles: []string{
+					"internal/ogc/features/testdata/geopackage/config_features_cql.yaml",
+					"internal/ogc/features/testdata/postgresql/config_features_cql.yaml",
+				},
+				url:          "http://localhost:8080/collections/:collectionId/items?prop3=Socc*",
+				collectionID: "cql",
+				contentCrs:   "<" + domain.WGS84CrsURI + ">",
+				format:       "json",
+			},
+			want: want{
+				body:       "internal/ogc/features/testdata/expected_features_part1_wildcard_filter.json",
+				statusCode: http.StatusOK,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/ogc/features/testdata/expected_features_part1_wildcard_filter.json
+++ b/internal/ogc/features/testdata/expected_features_part1_wildcard_filter.json
@@ -1,0 +1,70 @@
+{
+  "type": "FeatureCollection",
+  "timeStamp": "2000-01-01T00:00:00Z",
+  "links": [
+    {
+      "rel": "self",
+      "title": "This document as GeoJSON",
+      "type": "application/geo+json",
+      "href": "http://localhost:8080/collections/cql/items?f=json&prop3=Socc%2A"
+    },
+    {
+      "rel": "alternate",
+      "title": "This document as JSON-FG",
+      "type": "application/vnd.ogc.fg+json",
+      "href": "http://localhost:8080/collections/cql/items?f=jsonfg&prop3=Socc%2A"
+    },
+    {
+      "rel": "alternate",
+      "title": "This document as HTML",
+      "type": "text/html",
+      "href": "http://localhost:8080/collections/cql/items?f=html&prop3=Socc%2A"
+    }
+  ],
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "prop1": 4,
+        "prop10": "2026-02-26T23:00:00Z",
+        "prop2": 5,
+        "prop3": "Soccer",
+        "prop4": "FooBar",
+        "prop5": "2026-02-13",
+        "prop6": "2026-02-12T23:00:00Z",
+        "prop7": false,
+        "prop8": false,
+        "prop9": "2026-02-28"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              5.0413,
+              52.10192
+            ],
+            [
+              5.04164,
+              52.10197
+            ],
+            [
+              5.04167,
+              52.10168
+            ],
+            [
+              5.0413,
+              52.10168
+            ],
+            [
+              5.0413,
+              52.10192
+            ]
+          ]
+        ]
+      },
+      "id": "4"
+    }
+  ],
+  "numberReturned": 1
+}

--- a/internal/ogc/features/url.go
+++ b/internal/ogc/features/url.go
@@ -352,6 +352,11 @@ func parsePropertyFilters(configuredPropertyFilters map[string]datasources.Query
 				return nil, fmt.Errorf("property filter %s is too large, "+
 					"value is limited to %d characters", name, propertyFilterMaxLength)
 			}
+			if strings.Contains(pf, datasources.Wildcard) {
+				return nil, fmt.Errorf("property filter %s contains a '%s' symbol, which suggest "+
+					"you want to apply a wildcard filter. The correct wildcard symbol in OGC APIs is '%s'",
+					name, datasources.Wildcard, propertyFilterWildcard)
+			}
 			if strings.Contains(pf, propertyFilterWildcard) {
 				// In case CQL advanced comparison operators (LIKE operator) are enabled, wildcard filtering is allowed.
 				// Otherwise, it's not.
@@ -360,7 +365,7 @@ func parsePropertyFilters(configuredPropertyFilters map[string]datasources.Query
 						"wildcard filtering is not allowed", name, propertyFilterWildcard)
 				}
 				// replace wildcard with %, as this is the wildcard used in SQL.
-				pf = strings.ReplaceAll(pf, propertyFilterWildcard, "%")
+				pf = strings.ReplaceAll(pf, propertyFilterWildcard, datasources.Wildcard)
 			}
 			propertyFilters[name] = pf
 		}

--- a/internal/ogc/features/url_test.go
+++ b/internal/ogc/features/url_test.go
@@ -345,6 +345,25 @@ func TestParseFeatures(t *testing.T) {
 			},
 		},
 		{
+			name: "Fail on incorrect wildcard property filter",
+			fields: fields{
+				baseURL: *host,
+				params: url.Values{
+					"foo": []string{"baz%"},
+				},
+				limit: config.Limit{
+					Default: 10,
+					Max:     20,
+				},
+			},
+			wantErr: func(t assert.TestingT, err error, _ ...any) bool {
+				assert.EqualError(t, err, "property filter foo contains a '%' symbol, which suggest you want "+
+					"to apply a wildcard filter. The correct wildcard symbol in OGC APIs is '*'", "parse()")
+
+				return false
+			},
+		},
+		{
 			name: "Fail on too large property filter",
 			fields: fields{
 				baseURL: *host,


### PR DESCRIPTION
# Description

- filtering on wildcards in part 1 was forbidden. Now it's possible when part 3 wildcard filtering is enabled.

## Type of change

- Improvement of existing feature

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR