### PR TITLE
fix: always allow interval filtering

### DIFF
--- a/internal/ogc/features/url.go
+++ b/internal/ogc/features/url.go
@@ -101,7 +101,7 @@ func (fc featureCollectionURL) parse() (encodedCursor d.EncodedCursor, limit int
 	propertyFilters, pfErr := parsePropertyFilters(fc.configuredPropertyFilters, fc.params, fc.cqlConfig)
 	bbox, bboxSRID, bboxErr := ParseBbox(fc.params)
 	profile, profileErr := parseProfile(fc.params, fc.baseURL, fc.schema)
-	dateTime, dateTimeErr := parseDateTime(fc.params, fc.cqlConfig, fc.supportsDatetime)
+	dateTime, dateTimeErr := parseDateTime(fc.params, fc.supportsDatetime)
 	cqlFilter, filterSRID, filterErr := parseFilter(fc.params, fc.cqlConfig)
 	inputSRID, inputSRIDErr := consolidateSRIDs(bboxSRID, filterSRID)
 
@@ -378,7 +378,7 @@ func parsePropertyFilters(configuredPropertyFilters map[string]datasources.Query
 }
 
 // Support filtering on datetime: https://docs.ogc.org/is/17-069r4/17-069r4.html#_parameter_datetime
-func parseDateTime(params url.Values, cqlConfig config.CQL, datetimeSupported bool) (d.DateTime, error) {
+func parseDateTime(params url.Values, datetimeSupported bool) (d.DateTime, error) {
 	datetime := params.Get(dateTimeParam)
 	if datetime == "" {
 		return d.DateTime{}, nil
@@ -389,11 +389,6 @@ func parseDateTime(params url.Values, cqlConfig config.CQL, datetimeSupported bo
 
 	// parse interval
 	if strings.Contains(datetime, intervalSeparator) {
-		if !cqlConfig.IsEnabled() || !cqlConfig.EnableAdvancedComparisonOperators {
-			return d.DateTime{}, fmt.Errorf("datetime param '%s' represents an interval,"+
-				" interval filtering is not enabled for this collection", datetime)
-		}
-
 		parts := strings.SplitN(datetime, intervalSeparator, 2)
 		start, err := parseIntervalPart(parts[0])
 		if err != nil {

--- a/internal/ogc/features/url_test.go
+++ b/internal/ogc/features/url_test.go
@@ -611,26 +611,6 @@ func TestParseFeatures(t *testing.T) {
 			},
 		},
 		{
-			name: "Fail on disabled datetime interval",
-			fields: fields{
-				baseURL: *host,
-				params: url.Values{
-					"datetime": []string{"2023-11-10T23:00:00Z/2023-11-15T23:00:00Z"},
-				},
-				limit: config.Limit{
-					Default: 1,
-					Max:     2,
-				},
-				dtSupport: true,
-			},
-			wantErr: func(t assert.TestingT, err error, _ ...any) bool {
-				assert.EqualError(t, err, "datetime param '2023-11-10T23:00:00Z/2023-11-15T23:00:00Z' represents "+
-					"an interval, interval filtering is not enabled for this collection", "parse()")
-
-				return false
-			},
-		},
-		{
 			name: "Fail on invalid datetime",
 			fields: fields{
 				baseURL: *host,


### PR DESCRIPTION
# Description

fix: always allow interval filtering, since it's required by part 1 (new insight, we first made it dependent on part 3 conformance)

## Type of change

- Improvement of existing feature

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR