### PR TITLE
fix: allow only listed queryables, even in the case of spatial queries

### DIFF
--- a/internal/ogc/features/cql/cql_test.go
+++ b/internal/ogc/features/cql/cql_test.go
@@ -90,6 +90,29 @@ func TestFailOnNonQueryablePropertyQuery(t *testing.T) {
 	}
 }
 
+func TestFailOnNonQueryablePropertyWithGeomSpecifiedQuery(t *testing.T) {
+	// given
+	queryables := []domain.Field{{Name: "prop1"}}
+	inputCQL := "S_WITHIN(geometry, BBOX(4.993,51.889,5.552,52.137)) AND prop1 = 30 AND prop2 > 77"
+
+	for _, datasource := range datasources {
+		t.Run(datasource, func(t *testing.T) {
+			var err error
+
+			// when
+			switch datasource {
+			case gpkg:
+				_, err = ParseToSQL(inputCQL, NewGeoPackageListener(&util.MockRandomizer{}, queryables, 0, geospatial.Features, cqlConfigAllEnabled))
+			case postgresql:
+				_, err = ParseToSQL(inputCQL, NewPostgresListener(&util.MockRandomizer{}, queryables, 0, geospatial.Features, cqlConfigAllEnabled))
+			}
+
+			// then
+			assert.ErrorContains(t, err, "property 'prop2' cannot be used in CQL filter, is not a queryable property")
+		})
+	}
+}
+
 func TestPreventSQLInjectionAttack(t *testing.T) {
 	// given
 	queryables := []domain.Field{{Name: "prop1"}}

--- a/internal/ogc/features/cql/cql_test.go
+++ b/internal/ogc/features/cql/cql_test.go
@@ -67,7 +67,7 @@ func TestInvalidBooleanQuery(t *testing.T) {
 	}
 }
 
-func TestFailOnNonQueryablePropertyQuery(t *testing.T) {
+func TestFailOnNonQueryableProperty(t *testing.T) {
 	// given
 	queryables := []domain.Field{{Name: "prop1"}}
 	inputCQL := "prop1 = 30 AND prop2 > 77"
@@ -90,7 +90,7 @@ func TestFailOnNonQueryablePropertyQuery(t *testing.T) {
 	}
 }
 
-func TestFailOnNonQueryablePropertyWithGeomSpecifiedQuery(t *testing.T) {
+func TestFailOnNonQueryablePropertyWithGeomSpecified(t *testing.T) {
 	// given
 	queryables := []domain.Field{{Name: "prop1"}}
 	inputCQL := "S_WITHIN(geometry, BBOX(4.993,51.889,5.552,52.137)) AND prop1 = 30 AND prop2 > 77"
@@ -109,6 +109,29 @@ func TestFailOnNonQueryablePropertyWithGeomSpecifiedQuery(t *testing.T) {
 
 			// then
 			assert.ErrorContains(t, err, "property 'prop2' cannot be used in CQL filter, is not a queryable property")
+		})
+	}
+}
+
+func TestFailOnWronglyNamedGeometryProperty(t *testing.T) {
+	// given
+	queryables := []domain.Field{{Name: "prop1"}, {Name: "location", IsPrimaryGeometry: true}}
+	inputCQL := "S_WITHIN(location, BBOX(4.993,51.889,5.552,52.137)) AND prop1 = 30"
+
+	for _, datasource := range datasources {
+		t.Run(datasource, func(t *testing.T) {
+			var err error
+
+			// when
+			switch datasource {
+			case gpkg:
+				_, err = ParseToSQL(inputCQL, NewGeoPackageListener(&util.MockRandomizer{}, queryables, 0, geospatial.Features, cqlConfigAllEnabled))
+			case postgresql:
+				_, err = ParseToSQL(inputCQL, NewPostgresListener(&util.MockRandomizer{}, queryables, 0, geospatial.Features, cqlConfigAllEnabled))
+			}
+
+			// then
+			assert.ErrorContains(t, err, "spatial filtering is only supported on property 'geometry'")
 		})
 	}
 }
@@ -1727,6 +1750,38 @@ func TestAllSpatialFunctionsNotEnabled(t *testing.T) {
 
 			// then
 			assert.ErrorContains(t, err, "spatial operator 'S_OVERLAPS' is not enabled for this collection, only S_INTERSECTS is allowed")
+		})
+	}
+}
+
+func TestUseGeometryInCQLAndAnotherNameForGeometryColumnInSQL(t *testing.T) {
+	// given
+	queryables := []domain.Field{{Name: "prop1"}, {Name: "location", IsPrimaryGeometry: true}}
+	inputCQL := "S_WITHIN(geometry, BBOX(4.993,51.889,5.552,52.137)) AND prop1 = 30"
+	expectedSQLGeoPackage := "(ST_Within(CastAutomagic(\"location\"), BuildMbr(:cql_bcde, :cql_fghi, :cql_jklm, :cql_nopq, 100000)) AND cast (\"prop1\" as numeric) = :cql_rstu)"
+	expectedSQLPostgres := "(ST_Within(\"location\", ST_Transform(ST_MakeEnvelope(@cql_bcde, @cql_fghi, @cql_jklm, @cql_nopq, 4326), ST_SRID(\"location\"))) AND cast (\"prop1\" as numeric) = @cql_rstu)"
+
+	for _, datasource := range datasources {
+		t.Run(datasource, func(t *testing.T) {
+			var actual *SQLResult
+			var err error
+			switch datasource {
+			case gpkg:
+				// when
+				actual, err = ParseToSQL(inputCQL, NewGeoPackageListener(&util.MockRandomizer{}, queryables, 0, geospatial.Features, cqlConfigAllEnabled))
+
+				// then
+				require.NoError(t, err)
+				assertValidSQLiteQuery(t, actual)
+				assert.Equal(t, expectedSQLGeoPackage, actual.SQL)
+			case postgresql:
+				// when
+				actual, err = ParseToSQL(inputCQL, NewPostgresListener(&util.MockRandomizer{}, queryables, 0, geospatial.Features, cqlConfigAllEnabled))
+
+				// then
+				require.NoError(t, err)
+				assert.Equal(t, expectedSQLPostgres, actual.SQL)
+			}
 		})
 	}
 }

--- a/internal/ogc/features/cql/cql_test.go
+++ b/internal/ogc/features/cql/cql_test.go
@@ -44,6 +44,30 @@ func init() {
 	pwd = path.Dir(filename)
 }
 
+func TestEmptyInput(t *testing.T) {
+	// given
+	inputCQL := ""
+
+	for _, datasource := range datasources {
+		t.Run(datasource, func(t *testing.T) {
+			var actual *SQLResult
+			var err error
+
+			// when
+			switch datasource {
+			case gpkg:
+				_, err = ParseToSQL(inputCQL, NewGeoPackageListener(&util.MockRandomizer{}, []domain.Field{}, 0, geospatial.Features, cqlConfigAllEnabled))
+			case postgresql:
+				_, err = ParseToSQL(inputCQL, NewPostgresListener(&util.MockRandomizer{}, []domain.Field{}, 0, geospatial.Features, cqlConfigAllEnabled))
+			}
+
+			// then
+			require.Nil(t, actual)
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestInvalidBooleanQuery(t *testing.T) {
 	// given
 	inputCQL := "prop1 ==== 1 AND prop2 !!= 5"

--- a/internal/ogc/features/cql/listener_common.go
+++ b/internal/ogc/features/cql/listener_common.go
@@ -83,18 +83,26 @@ RETRY:
 	return
 }
 
-func (cl *CommonListener) allowAllQueryables() bool {
-	allowAll := len(cl.queryables) == 1 && cl.queryables[0].Name == "*"
-	if allowAll {
-		log.Println("WARNING: using '*' as queryable, this is not recommended")
+func (cl *CommonListener) isAllQueryablesAllowed() bool {
+	for _, q := range cl.queryables {
+		if q.Name == "*" {
+			log.Println("WARNING: using '*' as queryable, this is not recommended")
+			return true
+		}
 	}
-	return allowAll
+	return false
 }
 
 // isQueryable checks if a column name is allowed in the query.
 func (cl *CommonListener) isQueryable(name string) bool {
+	if cl.isAllQueryablesAllowed() {
+		return true
+	}
 	for _, q := range cl.queryables {
-		if q.Name == name || q.IsPrimaryGeometry {
+		if name == q.Name {
+			return true
+		}
+		if name == domain.GeomPropertyName && q.IsPrimaryGeometry {
 			return true
 		}
 	}

--- a/internal/ogc/features/cql/listener_geopackage.go
+++ b/internal/ogc/features/cql/listener_geopackage.go
@@ -109,7 +109,7 @@ func (l *GeoPackageListener) ExitSpatialPredicate(ctx *parser.SpatialPredicateCo
 
 	geomLiteral := l.stack.Pop()
 	geomProperty := l.stack.Pop()
-	if geomProperty != fmt.Sprintf("\"%s\"", d.GeomPropertyName) && !l.allowAllQueryables() {
+	if geomProperty != fmt.Sprintf("\"%s\"", d.GeomPropertyName) {
 		l.errorListener.Errorf("spatial filtering is only supported on property '%s'", d.GeomPropertyName)
 		return
 	}
@@ -121,7 +121,7 @@ func (l *GeoPackageListener) ExitSpatialPredicate(ctx *parser.SpatialPredicateCo
 			break
 		}
 	}
-	if geomColumn == "" && !l.allowAllQueryables() {
+	if geomColumn == "" && !l.isAllQueryablesAllowed() {
 		l.errorListener.Error("spatial filtering is not supported for this " +
 			"collection since there is no geometry field defined")
 		return
@@ -238,7 +238,7 @@ func (l *GeoPackageListener) ExitIntervalParameter(ctx *parser.IntervalParameter
 // ExitPropertyName Handle column names
 func (l *GeoPackageListener) ExitPropertyName(ctx *parser.PropertyNameContext) {
 	name := ctx.GetText()
-	if !l.allowAllQueryables() && !l.isQueryable(name) {
+	if !l.isQueryable(name) {
 		err := fmt.Sprintf("property '%s' cannot be used in CQL filter, is not a queryable property", name)
 		l.errorListener.Error(err)
 		return

--- a/internal/ogc/features/cql/listener_postgres.go
+++ b/internal/ogc/features/cql/listener_postgres.go
@@ -146,7 +146,7 @@ func (l *PostgresListener) ExitSpatialPredicate(ctx *parser.SpatialPredicateCont
 
 	geomLiteral := l.stack.Pop()
 	geomProperty := l.stack.Pop()
-	if geomProperty != fmt.Sprintf("\"%s\"", d.GeomPropertyName) && !l.allowAllQueryables() {
+	if geomProperty != fmt.Sprintf("\"%s\"", d.GeomPropertyName) {
 		l.errorListener.Errorf("spatial filtering is only supported on property '%s'", d.GeomPropertyName)
 		return
 	}
@@ -158,7 +158,7 @@ func (l *PostgresListener) ExitSpatialPredicate(ctx *parser.SpatialPredicateCont
 			break
 		}
 	}
-	if geomColumn == "" && !l.allowAllQueryables() {
+	if geomColumn == "" && !l.isAllQueryablesAllowed() {
 		l.errorListener.Error("spatial filtering is not supported for this " +
 			"collection since there is no geometry field defined")
 		return
@@ -278,7 +278,7 @@ func (l *PostgresListener) ExitInstantInstance(ctx *parser.InstantInstanceContex
 // ExitPropertyName Handle column names
 func (l *PostgresListener) ExitPropertyName(ctx *parser.PropertyNameContext) {
 	name := ctx.GetText()
-	if !l.allowAllQueryables() && !l.isQueryable(name) {
+	if !l.isQueryable(name) {
 		err := fmt.Sprintf("property '%s' cannot be used in CQL filter, is not a queryable property", name)
 		l.errorListener.Error(err)
 		return

--- a/internal/ogc/features/features_test.go
+++ b/internal/ogc/features/features_test.go
@@ -951,6 +951,23 @@ func TestFeatures(t *testing.T) {
 			},
 		},
 		{
+			name: "Request features with CQL filter for non-queryable properties",
+			fields: fields{
+				configFiles: []string{
+					"internal/ogc/features/testdata/geopackage/config_features_cql.yaml",
+					"internal/ogc/features/testdata/postgresql/config_features_cql.yaml",
+				},
+				url:          "http://localhost:8080/collections/:collectionId/items?f=json&filter=S_INTERSECTS(geometry, POINT(5.0403692 52.1017868)) AND fid > 2 AND prop2 = 6",
+				collectionID: "cql",
+				contentCrs:   "<" + domain.WGS84CrsURI + ">",
+				format:       "json",
+			},
+			want: want{
+				body:       "internal/ogc/features/testdata/expected_features_cql_non_queryable.json",
+				statusCode: http.StatusBadRequest,
+			},
+		},
+		{
 			name: "Request features with comparison CQL filter",
 			fields: fields{
 				configFiles: []string{

--- a/internal/ogc/features/testdata/expected_features_cql_non_queryable.json
+++ b/internal/ogc/features/testdata/expected_features_cql_non_queryable.json
@@ -1,0 +1,6 @@
+{
+  "detail": "failed to parse CQL filter:\nerror: property 'fid' cannot be used in CQL filter, is not a queryable property",
+  "status": 400,
+  "timeStamp": "2000-01-01T00:00:00Z",
+  "title": "Bad Request"
+}


### PR DESCRIPTION
# Description

fix: allow only allowed queryables, even in the case of spatial queries

## Type of change

- Bugfix

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR