### PR TITLE
projections project properly for both osm and brt

### DIFF
--- a/viewer/src/app/feature-view/feature-view.component.ts
+++ b/viewer/src/app/feature-view/feature-view.component.ts
@@ -354,7 +354,7 @@ export class FeatureViewComponent implements OnChanges, AfterViewInit, OnDestroy
     return new Tile({
       source: new WMTSSource({
         attributions: 'Kaartgegevens: &copy; <a href="https://www.kadaster.nl">Kadaster</a>',
-        url: environment.bgt.backgroundUrl,
+        url: environment.brt.backgroundUrl,
         layer: 'grijs',
         matrixSet: p.projection.getCode(),
         format: 'image/png',

--- a/viewer/src/app/shared/model/map-projection.ts
+++ b/viewer/src/app/shared/model/map-projection.ts
@@ -3,6 +3,7 @@ import proj4 from 'proj4'
 import { CrsMap } from './crs-map'
 import { register } from 'ol/proj/proj4'
 import { NGXLogger } from 'ngx-logger'
+import { get as getProj } from 'ol/proj'
 
 export const NetherlandsRDNewQuadDefault = 'NetherlandsRDNewQuad'
 export const EuropeanETRS89_LAEAQuad = 'EuropeanETRS89_LAEAQuad'
@@ -55,7 +56,8 @@ export function initProj4WithDynamicCrs(crsMap: CrsMap, logger: NGXLogger) {
     Object.keys(crsMap).forEach(key => {
       if (key === CRS_84_SRID) return // skip CRS84 as it ships with proj4js
       const proj4def = crsMap[key]
-      proj4.defs(EPSG_PREFIX + key, proj4def)
+      const code = EPSG_PREFIX + key
+      if (!getProj(code)) proj4.defs(code, proj4def)
     })
   } catch (error) {
     logger.error(`Error registering projections: ${error}`)

--- a/viewer/src/app/shared/services/feature.service.ts
+++ b/viewer/src/app/shared/services/feature.service.ts
@@ -164,8 +164,8 @@ export class FeatureService {
     // If no value is passed to the component use CRS84 for data and EPSG:3857 (wgs 84) for rendering
     if (!value) return defaultMapping
     const projection = this.getProjectionCodeFromUrl(value)
-    // if bgt background supports the projection, return it. Else default to wgs 84
-    if (environment.bgt.projections.includes(projection)) return { dataProjection: projection, visualProjection: projection }
+    // if brt background supports the projection, return it. Else default to wgs 84
+    if (environment.brt.projections.includes(projection)) return { dataProjection: projection, visualProjection: projection }
     else return { dataProjection: projection, visualProjection: 'EPSG:3857' }
   }
 

--- a/viewer/src/environments/environment.development.ts
+++ b/viewer/src/environments/environment.development.ts
@@ -1,7 +1,7 @@
 import { NgxLoggerLevel } from 'ngx-logger'
 
 export const environment = {
-  bgt: {
+  brt: {
     backgroundUrl: 'https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0?',
     projections: ['EPSG:28992', 'EPSG:25831', 'EPSG:3857'],
   },

--- a/viewer/src/environments/environment.ts
+++ b/viewer/src/environments/environment.ts
@@ -1,7 +1,7 @@
 import { NgxLoggerLevel } from 'ngx-logger'
 
 export const environment = {
-  bgt: {
+  brt: {
     backgroundUrl: 'https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0?',
     projections: ['EPSG:28992', 'EPSG:3035', 'EPSG:3857'],
   },


### PR DESCRIPTION
# Description
Implemented a fix where the WGS 84 would get overwritten by a custom PROJ-definition. 
Solution is a fix where we check if proj definitions exist before registering them.

## Type of change

- Bugfix


# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR