### PR TITLE
fix: wcag issue where aria labels don't include visible text

### DIFF
--- a/internal/ogc/common/core/templates/landing-page.go.html
+++ b/internal/ogc/common/core/templates/landing-page.go.html
@@ -64,7 +64,7 @@
                         {{ i18n "Support" }}
                     </td>
                     <td>
-                        <a href="{{ .Config.Support.URL }}" target="_blank" aria-label="{{ i18n "To" }} {{ i18n "Support" }}">{{ .Config.Support.Name }}</a>
+                        <a href="{{ .Config.Support.URL }}" target="_blank" aria-label="{{ i18n "To" }} {{ i18n "Support" }}: {{ .Config.Support.Name }}">{{ .Config.Support.Name }}</a>
                     </td>
                 </tr>
                 {{ end }}


### PR DESCRIPTION
# Description
In WCAG 2.1, visible text in links need to be in the aria-label for screen-readers to resolve. Since this doesn't happen, issues might occur when someone uses a screen-reader.

## Type of change
- Improvement of existing feature

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR