### PR TITLE
fix: missing CRS in HTML view of features search

### DIFF
--- a/internal/ogc/features/html.go
+++ b/internal/ogc/features/html.go
@@ -35,11 +35,11 @@ func newHTMLFeatures(e *engine.Engine, projJSONBySRID map[int]string) *htmlFeatu
 
 	return &htmlFeatures{
 		engine:         e,
-		projJSONBySRID: convertProjJSONBySRIDtoString(projJSONBySRID),
+		projJSONBySRID: ConvertProjJSONBySRIDtoString(projJSONBySRID),
 	}
 }
 
-func convertProjJSONBySRIDtoString(projJSONBySRID map[int]string) string {
+func ConvertProjJSONBySRIDtoString(projJSONBySRID map[int]string) string {
 	projJSONRaw := make(map[int]json.RawMessage)
 	for key, projJSON := range projJSONBySRID {
 		projJSONRaw[key] = json.RawMessage(projJSON)
@@ -51,7 +51,6 @@ func convertProjJSONBySRIDtoString(projJSONBySRID map[int]string) string {
 	}
 
 	return string(projJSON)
-
 }
 
 // featureCollectionPage enriched FeatureCollection for HTML representation.

--- a/internal/ogc/features_search/main.go
+++ b/internal/ogc/features_search/main.go
@@ -37,8 +37,12 @@ type Search struct {
 	json *jsonSearchResults
 }
 
+type searchPage struct {
+	ProjJSON string
+}
+
 func NewSearch(e *engine.Engine, datasources map[features.DatasourceKey]ds.Datasource,
-	axisOrderBySRID map[int]fd.AxisOrder, rewritesFile, synonymsFile string, maxSynonyms int) (*Search, error) {
+	projJSONBySRID map[int]string, rewritesFile, synonymsFile string, maxSynonyms int) (*Search, error) {
 
 	if synonymsFile == "" {
 		return nil, errors.New("synonyms.csv file not configured, this is required for features search")
@@ -59,13 +63,16 @@ func NewSearch(e *engine.Engine, datasources map[features.DatasourceKey]ds.Datas
 	s := &Search{
 		engine:          e,
 		datasource:      searchDS,
-		axisOrderBySRID: axisOrderBySRID,
+		axisOrderBySRID: features.GetAxisOrderBySRID(projJSONBySRID),
 		json:            newJSONSearchResults(e),
 		queryExpansion:  queryExpansion,
 	}
 	e.Router.Get(searchPath, s.Search())
 
-	e.RenderTemplates(searchPath,
+	e.RenderTemplatesWithParams(searchPath,
+		searchPage{
+			ProjJSON: features.ConvertProjJSONBySRIDtoString(projJSONBySRID),
+		},
 		[]engine.Breadcrumb{{Name: "Search", Path: "search"}},
 		engine.NewTemplateKey(templatesDir+searchHTML))
 

--- a/internal/ogc/features_search/main_test.go
+++ b/internal/ogc/features_search/main_test.go
@@ -72,7 +72,7 @@ func TestSearch(t *testing.T) {
 	require.NoError(t, err)
 
 	// given available engine + datasources
-	theEngine, datasources, axisOrderBySRID := newEngine(t)
+	theEngine, datasources, projJSONBySRID := newEngine(t)
 
 	// given imported geopackage
 	err = importGpkg("addresses", dbConn) // in CRS84
@@ -81,7 +81,7 @@ func TestSearch(t *testing.T) {
 	require.NoError(t, err)
 
 	// given search endpoint
-	searchEndpoint, err := NewSearch(theEngine, datasources, axisOrderBySRID,
+	searchEndpoint, err := NewSearch(theEngine, datasources, projJSONBySRID,
 		"internal/ogc/features_search/testdata/rewrites.csv",
 		"internal/ogc/features_search/testdata/synonyms.csv",
 		theEngine.Config.OgcAPI.FeaturesSearch.SearchSettings.MaxSynonyms)
@@ -468,7 +468,7 @@ func TestSearch(t *testing.T) {
 	}
 }
 
-func newEngine(t *testing.T) (*engine.Engine, map[features.DatasourceKey]ds.Datasource, map[int]fd.AxisOrder) {
+func newEngine(t *testing.T) (*engine.Engine, map[features.DatasourceKey]ds.Datasource, map[int]string) {
 	t.Helper()
 	theEngine, err := engine.NewEngine(searchConfigFile, "", "", false, false)
 	require.NoError(t, err)
@@ -481,9 +481,8 @@ func newEngine(t *testing.T) (*engine.Engine, map[features.DatasourceKey]ds.Data
 	datasources := features.CreateDatasources(
 		config.NewSearchConfig(theEngine.Config.OgcAPI.FeaturesSearch), theEngine.RegisterShutdownHook)
 	projInfoMap := features.GetProjJSONBySRID(datasources)
-	axisOrderBySRID := features.GetAxisOrderBySRID(projInfoMap)
 
-	return theEngine, datasources, axisOrderBySRID
+	return theEngine, datasources, projInfoMap
 }
 
 func importGpkg(collectionName string, dbConn string) error {

--- a/internal/ogc/features_search/templates/search.go.html
+++ b/internal/ogc/features_search/templates/search.go.html
@@ -61,6 +61,7 @@
                     class="card"
                     initial-view="VISIBLE"
                     show-bounding-box-button="true"
+                    crs-map="{{ .Params.ProjJSON }}"
             > </app-feature-view>
             <section aria-labelledby="current-features-label">
                 <p id="current-features-label" class="mb-1">{{ i18n "CurrentFeatures" }}:</p>

--- a/internal/ogc/setup.go
+++ b/internal/ogc/setup.go
@@ -37,8 +37,7 @@ func SetupBuildingBlocks(engine *engine.Engine, rewritesFile, synonymsFile strin
 		fs := engine.Config.OgcAPI.FeaturesSearch
 		ds := features.CreateDatasources(config.NewSearchConfig(fs), engine.RegisterShutdownHook)
 		projInfoMap := features.GetProjJSONBySRID(ds)
-		ao := features.GetAxisOrderBySRID(projInfoMap)
-		_, err := features_search.NewSearch(engine, ds, ao, rewritesFile, synonymsFile, fs.SearchSettings.MaxSynonyms)
+		_, err := features_search.NewSearch(engine, ds, projInfoMap, rewritesFile, synonymsFile, fs.SearchSettings.MaxSynonyms)
 		if err != nil {
 			return err
 		}

--- a/viewer/src/app/feature-view/feature-view.component.ts
+++ b/viewer/src/app/feature-view/feature-view.component.ts
@@ -154,8 +154,8 @@ export class FeatureViewComponent implements OnChanges, AfterViewInit, OnDestroy
         this.loadFeatures(this.features)
         this.addFeatureEmit()
         this.loadBackground()
-        this.logger.log(this.map.getView().getProjection())
-        this.logger.log('resolution' + this.map.getView().getResolution())
+        this.logger.debug(this.map.getView().getProjection())
+        this.logger.debug('resolution' + this.map.getView().getResolution())
       })
   }
 

--- a/viewer/src/app/shared/model/map-projection.ts
+++ b/viewer/src/app/shared/model/map-projection.ts
@@ -53,6 +53,7 @@ function initProj4WithTilesDefaults(logger: NGXLogger) {
 
 export function initProj4WithDynamicCrs(crsMap: CrsMap, logger: NGXLogger) {
   try {
+    if (Object.keys(crsMap).length === 0) logger.warn('No CRS defined, only the default projection for OL (WGS84) is available')
     Object.keys(crsMap).forEach(key => {
       if (key === CRS_84_SRID) return // skip CRS84 as it ships with proj4js
       const proj4def = crsMap[key]


### PR DESCRIPTION
# Description
Fixed the location search page which had no crs-map defined.
Also added logging to warn about this behaviour in the future

## Type of change
- Bugfix


# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR