### PR TITLE
fix: replace OAF part 1 property filter wildcard (*) in datasource layer

### DIFF
--- a/examples/config_all.yaml
+++ b/examples/config_all.yaml
@@ -117,6 +117,8 @@ ogcApi:
               indexRequired: false
             - name: locator_designator_addressnumberextension
               indexRequired: false
+            - name: component_thoroughfarename
+              indexRequired: false
           cql:
             enable: true
 

--- a/internal/ogc/features/datasources/common/common.go
+++ b/internal/ogc/features/datasources/common/common.go
@@ -182,7 +182,9 @@ func PropertyFiltersToSQL(pf map[string]string, symbol string) (sql string, name
 		for k, v := range pf {
 			position++
 			namedParam := fmt.Sprintf("pf%d", position)
-			if strings.Contains(v, datasources.Wildcard) {
+			if strings.Contains(v, domain.PropertyFilterWildcard) {
+				// replace wildcard with %, as this is the wildcard used in SQL.
+				v = strings.ReplaceAll(v, domain.PropertyFilterWildcard, domain.Wildcard)
 				fmt.Fprintf(&sqlBuilder, " and \"%s\" like %s%s", k, symbol, namedParam)
 			} else {
 				fmt.Fprintf(&sqlBuilder, " and \"%s\" = %s%s", k, symbol, namedParam)

--- a/internal/ogc/features/datasources/datasource.go
+++ b/internal/ogc/features/datasources/datasource.go
@@ -10,8 +10,6 @@ import (
 	"github.com/twpayne/go-geom"
 )
 
-const Wildcard = "%"
-
 // Datasource holds all Features for a single object type in a specific projection/CRS.
 // This abstraction allows the rest of the system to stay datastore agnostic <== IMPORTANT.
 type Datasource interface {

--- a/internal/ogc/features/domain/queryables.go
+++ b/internal/ogc/features/domain/queryables.go
@@ -1,5 +1,10 @@
 package domain
 
+const (
+	PropertyFilterWildcard = "*" // used as wildcard in OAF part 1
+	Wildcard               = "%" // used as wildcard in CQL and SQL
+)
+
 // Queryables one or more QueryableWithAllowedValues indexed by queryable name.
 type Queryables map[string]QueryableWithAllowedValues
 

--- a/internal/ogc/features/url.go
+++ b/internal/ogc/features/url.go
@@ -15,7 +15,6 @@ import (
 	"github.com/PDOK/gokoala/config"
 	"github.com/PDOK/gokoala/internal/engine"
 	"github.com/PDOK/gokoala/internal/engine/util"
-	"github.com/PDOK/gokoala/internal/ogc/features/datasources"
 	d "github.com/PDOK/gokoala/internal/ogc/features/domain"
 	"github.com/twpayne/go-geom"
 )
@@ -36,7 +35,6 @@ const (
 	cqlJSON = "cql2-json"
 
 	propertyFilterMaxLength = 512
-	propertyFilterWildcard  = "*"
 
 	intervalSeparator   = "/"
 	intervalHalfBounded = ".."
@@ -361,20 +359,18 @@ func parsePropertyFilters(configuredPropertyFilters map[string]d.QueryableWithAl
 				return nil, fmt.Errorf("property filter %s is too large, "+
 					"value is limited to %d characters", name, propertyFilterMaxLength)
 			}
-			if strings.Contains(pf, datasources.Wildcard) {
+			if strings.Contains(pf, d.Wildcard) {
 				return nil, fmt.Errorf("property filter %s contains a '%s' symbol, which suggest "+
 					"you want to apply a wildcard filter. The correct wildcard symbol in OGC APIs is '%s'",
-					name, datasources.Wildcard, propertyFilterWildcard)
+					name, d.Wildcard, d.PropertyFilterWildcard)
 			}
-			if strings.Contains(pf, propertyFilterWildcard) {
+			if strings.Contains(pf, d.PropertyFilterWildcard) {
 				// In case CQL advanced comparison operators (LIKE operator) are enabled, wildcard filtering is allowed.
 				// Otherwise, it's not.
 				if !cqlConfig.IsEnabled() || !cqlConfig.EnableAdvancedComparisonOperators {
 					return nil, fmt.Errorf("property filter %s contains a wildcard (%s), "+
-						"wildcard filtering is not allowed", name, propertyFilterWildcard)
+						"wildcard filtering is not allowed", name, d.PropertyFilterWildcard)
 				}
-				// replace wildcard with %, as this is the wildcard used in SQL.
-				pf = strings.ReplaceAll(pf, propertyFilterWildcard, datasources.Wildcard)
 			}
 			propertyFilters[name] = pf
 		}


### PR DESCRIPTION
# Description

fix: replace OAF part 1 property filter wildcard (*) in datasource layer instead of during URL validation to prevent side-effects in frontend.

Semi-related, also reported: https://github.com/opengeospatial/ogcapi-features/issues/1059

## Type of change

- Bugfix

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR