### PR TITLE
fix: OpenAPI specs now pass newer ADR validation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ See our [end-to-end tests](tests/README.md) for details.
 ### How to Contribute
 
 Make a pull request. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
-Also see [CONTRIBUTING](CONTRIBUTING.md) for details about contributing to PDOK software.
+Also see [CONTRIBUTING](CONTRIBUTING.md) for instructions about contributing to PDOK software.
 
 ### Contact
 

--- a/internal/engine/templates/openapi/common-collections.go.json
+++ b/internal/engine/templates/openapi/common-collections.go.json
@@ -255,9 +255,9 @@
             "format": "uri"
           },
           "storageCrsCoordinateEpoch": {
-            "description": "point in time at which coordinates in the spatial feature collection are referenced to the dynamic coordinate reference system in `storageCrs`, that may be used to retrieve features from a collection without the need to apply a change of coordinate epoch. It is expressed as a decimal year in the Gregorian calendar",
+            "description": "point in time at which coordinates in the spatial feature collection are referenced to the dynamic coordinate reference system in `storageCrs`, that may be used to retrieve features from a collection without the need to apply a change of coordinate epoch. It is expressed as a decimal year in the Gregorian calendar, for example 2017-03-25 in the Gregorian calendar is epoch 2017.23",
             "type": "number",
-            "example": "2017-03-25 in the Gregorian calendar is epoch 2017.23"
+            "example": 2017.23
           }
           {{- end -}}
         }
@@ -350,13 +350,7 @@
           "items": {
             "type": "number"
           }
-        },
-        "example": [
-            7.01,
-            50.63,
-            7.22,
-            50.78
-        ]
+        }
       },
       "crs": {
         "description": "Coordinate reference system of the coordinates in the spatial extent\n(property `bbox`). The default reference system is WGS 84 longitude/latitude.",
@@ -412,12 +406,10 @@
         ],
         "properties": {
           "title": {
-            "type": "string",
-            "example": "Buildings in Bonn"
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "example": "Access to data about buildings in the city of Bonn via a Web API that conforms to the OGC API Features specification."
+            "type": "string"
           },
           "links": {
             "type": "array",
@@ -425,51 +417,7 @@
               "$ref": "#/components/schemas/link"
             }
           }
-        },
-        "example": [
-          {
-            "href": "http://data.example.org/?f=json",
-            "rel": "self",
-            "type": "application/json",
-            "title": "this document"
-          },
-          {
-            "href": "http://data.example.org/?f=html",
-            "rel": "alternate",
-            "type": "text/html",
-            "title": "this document in HTML"
-          },
-          {
-            "href": "http://data.example.org/api?f=json",
-            "rel": "service",
-            "type": "application/vnd.oai.openapi+json;version=3.0",
-            "title": "the API definition in OpenAPI 3.0 JSON"
-          },
-          {
-            "href": "http://data.example.org/api?f=html",
-            "rel": "service",
-            "type": "text/html",
-            "title": "the API definition in HTML"
-          },
-          {
-            "href": "http://data.example.org/conformance?f=json",
-            "rel": "conformance",
-            "type": "application/json",
-            "title": "the list of conformance classes implemented by this API"
-          },
-          {
-            "href": "http://data.example.org/collections?f=json",
-            "rel": "data",
-            "type": "application/json",
-            "title": "The collections in the dataset in JSON"
-          },
-          {
-            "href": "http://data.example.org/collections?f=html",
-            "rel": "data",
-            "type": "text/html",
-            "title": "The collections in the dataset in HTML"
-          }
-        ]
+        }
       },
       "id-link": {
         "type": "object",

--- a/internal/engine/templates/openapi/common.go.json
+++ b/internal/engine/templates/openapi/common.go.json
@@ -151,8 +151,7 @@
         ],
         "properties": {
           "title": {
-            "type": "string",
-            "example": "Buildings in Bonn"
+            "type": "string"
           },
           "description": {
             "type": "string"

--- a/internal/engine/templates/openapi/tiles.go.json
+++ b/internal/engine/templates/openapi/tiles.go.json
@@ -230,19 +230,10 @@
         ],
         "properties": {
           "title": {
-            "type": "string",
-            "title": "The title of the API.",
-            "description": "While a title is not required, implementors are strongly advised to include one.",
-            "example": "Buildings in Bonn"
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "example": "Access to data about buildings in the city of Bonn via a Web API that conforms to the OGC API Common specification."
-          },
-          "attribution": {
-            "type": "string",
-            "title": "attribution for the API",
-            "description": "The `attribution` should be short and intended for presentation to a user, for example, in a corner of a map. Parts of the text can be links to other resources if additional information is needed. The string can include HTML markup."
+            "type": "string"
           },
           "links": {
             "type": "array",

--- a/internal/ogc/common/core/main_test.go
+++ b/internal/ogc/common/core/main_test.go
@@ -190,7 +190,7 @@ func TestCommonCore_API(t *testing.T) {
 				url:        "http://localhost:8080/api?f=json",
 			},
 			want: want{
-				body:       "OpenAPI",
+				body:       "\"openapi\":",
 				statusCode: http.StatusOK,
 			},
 		},
@@ -222,7 +222,9 @@ func TestCommonCore_API(t *testing.T) {
 			handler.ServeHTTP(rr, req)
 
 			assert.Equal(t, tt.want.statusCode, rr.Code)
-			assert.Contains(t, rr.Body.String(), tt.want.body)
+			actualBody := rr.Body.String()
+			log.Print("ACTUAL:\n" + actualBody)
+			assert.Contains(t, actualBody, tt.want.body)
 		})
 	}
 }


### PR DESCRIPTION
# Description

fix: OpenAPI specs now pass newer ADR validation rules

## Type of change

- Improvement of existing feature

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR